### PR TITLE
WIP: Directions API v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "uglify-js": "^2.4.24"
   },
   "peerDependencies": {
-    "mapbox-gl": "^0.11.1"
+    "mapbox-gl": "git://github.com/user/project.git#directions-v5"
   },
   "dependencies": {
     "lodash.debounce": "^3.1.1",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -103,8 +103,9 @@ function fetchDirections() {
     const { routeIndex, profile } = getState();
     const query = buildDirectionsQuery(getState);
     return mapbox.getDirections(query, {
-      profile: 'mapbox.' + profile,
-      geometry: 'polyline'
+      profile: profile,
+      geometry: 'polyline',
+      overview: 'full'
     }, (err, res) => {
       if (err) throw err;
       if (res.error) return dispatch(setError(res.error));
@@ -113,8 +114,8 @@ function fetchDirections() {
       dispatch(setDirections(res.routes));
 
       // Revise origin / destination points
-      dispatch(originPoint(res.origin.geometry.coordinates));
-      dispatch(destinationPoint(res.destination.geometry.coordinates));
+      dispatch(originPoint(res.waypoints[0].location));
+      dispatch(destinationPoint(res.waypoints[res.waypoints.length - 1].location));
     });
   };
 }

--- a/src/controls/instructions.js
+++ b/src/controls/instructions.js
@@ -37,11 +37,11 @@ export default class Instructions {
       }
 
       if (directions.length && shouldRender) {
-        const direction = this.directions = directions[routeIndex];
+        const direction = directions[routeIndex];
         this.container.innerHTML = instructionsTemplate({
           routeIndex,
           routes: directions.length,
-          steps: direction.steps,
+          steps: direction.legs[0].steps, // Todo: Respect all legs
           format: format[unit],
           duration: format[unit](direction.distance),
           distance: format.duration(direction.duration)

--- a/src/directions.js
+++ b/src/directions.js
@@ -182,11 +182,10 @@ export default class Directions extends mapboxgl.Control {
 
       if (directions.length) {
         directions.forEach((feature, index) => {
-
           const lineString = {
             geometry: {
               type: 'LineString',
-              coordinates: decode(feature.geometry, 6).map((c) => {
+              coordinates: decode(feature.geometry, 5).map((c) => {
                 return c.reverse();
               })
             },
@@ -199,18 +198,19 @@ export default class Directions extends mapboxgl.Control {
           geojson.features.push(lineString);
 
           if (index === routeIndex) {
+            // TODO: respect each leg (no need for searching waypoints anymore)
             // Collect any possible waypoints from steps
-            feature.steps.forEach((d) => {
-              if (d.maneuver.type === 'waypoint') {
-                geojson.features.push({
-                  type: 'Feature',
-                  geometry: d.maneuver.location,
-                  properties: {
-                    id: 'waypoint'
-                  }
-                });
-              }
-            });
+            //feature.steps.forEach((d) => {
+              //if (d.maneuver.type === 'waypoint') {
+                //geojson.features.push({
+                  //type: 'Feature',
+                  //geometry: d.maneuver.location,
+                  //properties: {
+                    //id: 'waypoint'
+                  //}
+                //});
+              //}
+            //});
           }
 
         });

--- a/src/templates/instructions.html
+++ b/src/templates/instructions.html
@@ -18,8 +18,8 @@
         <%
           var distance = step.distance ? format(step.distance) : false;
           var icon = step.maneuver.type.replace(/\s+/g, '-').toLowerCase();
-          var lng = step.maneuver.location.coordinates[0];
-          var lat = step.maneuver.location.coordinates[1];
+          var lng = step.maneuver.location[0];
+          var lat = step.maneuver.location[1];
         %>
         <li
           data-lat='<%= lat %>'
@@ -31,7 +31,7 @@
           </div>
           <% if (step.distance) { %>
             <div class='mapbox-directions-step-distance'>
-              <%= distance %>
+              <%= step.distance %>
             </div>
           <% } %>
         </li>


### PR DESCRIPTION
The preliminary docs can be found [here](https://www.mapbox.com/developers/api/directions-v5/)

Todo:

- [ ] Make correct use of `route.legs` for waypoints instead of the current hacking
- [ ] Wait for `overview: simplified` geometry to be fixed upstream and use that instead of the full geometry
- [ ] Wait for more specs on how instructions will actually work
- [ ] Probably tests

@tristen do you think you could tackle the legs stuff?