### PR TITLE
Defer mapboxgl dependency to runtime

### DIFF
--- a/dist/mapbox-gl-directions.js
+++ b/dist/mapbox-gl-directions.js
@@ -37,7 +37,7 @@ if (window.mapboxgl) {
    * @return {Directions} `this`
    */
 
-},{"./src/directions":42}],2:[function(require,module,exports){
+},{"./src/directions":36}],2:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -497,436 +497,7 @@ module.exports = reInterpolate;
 },{}],5:[function(require,module,exports){
 (function (global){
 /**
- * lodash 3.0.1 (Custom Build) <https://lodash.com/>
- * Build: `lodash modularize exports="npm" -o ./`
- * Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
- * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
- * Copyright 2009-2016 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
- * Available under MIT license <https://lodash.com/license>
- */
-
-/** Used to determine if values are of the language type `Object`. */
-var objectTypes = {
-  'function': true,
-  'object': true
-};
-
-/** Detect free variable `exports`. */
-var freeExports = (objectTypes[typeof exports] && exports && !exports.nodeType)
-  ? exports
-  : undefined;
-
-/** Detect free variable `module`. */
-var freeModule = (objectTypes[typeof module] && module && !module.nodeType)
-  ? module
-  : undefined;
-
-/** Detect free variable `global` from Node.js. */
-var freeGlobal = checkGlobal(freeExports && freeModule && typeof global == 'object' && global);
-
-/** Detect free variable `self`. */
-var freeSelf = checkGlobal(objectTypes[typeof self] && self);
-
-/** Detect free variable `window`. */
-var freeWindow = checkGlobal(objectTypes[typeof window] && window);
-
-/** Detect `this` as the global object. */
-var thisGlobal = checkGlobal(objectTypes[typeof this] && this);
-
-/**
- * Used as a reference to the global object.
- *
- * The `this` value is used if it's the global object to avoid Greasemonkey's
- * restricted `window` object, otherwise the `window` object is used.
- */
-var root = freeGlobal ||
-  ((freeWindow !== (thisGlobal && thisGlobal.window)) && freeWindow) ||
-    freeSelf || thisGlobal || Function('return this')();
-
-/**
- * Checks if `value` is a global object.
- *
- * @private
- * @param {*} value The value to check.
- * @returns {null|Object} Returns `value` if it's a global object, else `null`.
- */
-function checkGlobal(value) {
-  return (value && value.Object === Object) ? value : null;
-}
-
-module.exports = root;
-
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],6:[function(require,module,exports){
-/**
  * lodash (Custom Build) <https://lodash.com/>
- * Build: `lodash modularize exports="npm" -o ./`
- * Copyright jQuery Foundation and other contributors <https://jquery.org/>
- * Released under MIT license <https://lodash.com/license>
- * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
- * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
- */
-var keysIn = require('lodash.keysin'),
-    rest = require('lodash.rest');
-
-/** Used as references for various `Number` constants. */
-var MAX_SAFE_INTEGER = 9007199254740991;
-
-/** `Object#toString` result references. */
-var funcTag = '[object Function]',
-    genTag = '[object GeneratorFunction]';
-
-/** Used to detect unsigned integer values. */
-var reIsUint = /^(?:0|[1-9]\d*)$/;
-
-/** Used for built-in method references. */
-var objectProto = Object.prototype;
-
-/** Used to check objects for own properties. */
-var hasOwnProperty = objectProto.hasOwnProperty;
-
-/**
- * Used to resolve the
- * [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
- * of values.
- */
-var objectToString = objectProto.toString;
-
-/**
- * Assigns `value` to `key` of `object` if the existing value is not equivalent
- * using [`SameValueZero`](http://ecma-international.org/ecma-262/6.0/#sec-samevaluezero)
- * for equality comparisons.
- *
- * @private
- * @param {Object} object The object to modify.
- * @param {string} key The key of the property to assign.
- * @param {*} value The value to assign.
- */
-function assignValue(object, key, value) {
-  var objValue = object[key];
-  if (!(hasOwnProperty.call(object, key) && eq(objValue, value)) ||
-      (value === undefined && !(key in object))) {
-    object[key] = value;
-  }
-}
-
-/**
- * The base implementation of `_.property` without support for deep paths.
- *
- * @private
- * @param {string} key The key of the property to get.
- * @returns {Function} Returns the new accessor function.
- */
-function baseProperty(key) {
-  return function(object) {
-    return object == null ? undefined : object[key];
-  };
-}
-
-/**
- * Copies properties of `source` to `object`.
- *
- * @private
- * @param {Object} source The object to copy properties from.
- * @param {Array} props The property identifiers to copy.
- * @param {Object} [object={}] The object to copy properties to.
- * @param {Function} [customizer] The function to customize copied values.
- * @returns {Object} Returns `object`.
- */
-function copyObject(source, props, object, customizer) {
-  object || (object = {});
-
-  var index = -1,
-      length = props.length;
-
-  while (++index < length) {
-    var key = props[index];
-
-    var newValue = customizer
-      ? customizer(object[key], source[key], key, object, source)
-      : source[key];
-
-    assignValue(object, key, newValue);
-  }
-  return object;
-}
-
-/**
- * Creates a function like `_.assign`.
- *
- * @private
- * @param {Function} assigner The function to assign values.
- * @returns {Function} Returns the new assigner function.
- */
-function createAssigner(assigner) {
-  return rest(function(object, sources) {
-    var index = -1,
-        length = sources.length,
-        customizer = length > 1 ? sources[length - 1] : undefined,
-        guard = length > 2 ? sources[2] : undefined;
-
-    customizer = (assigner.length > 3 && typeof customizer == 'function')
-      ? (length--, customizer)
-      : undefined;
-
-    if (guard && isIterateeCall(sources[0], sources[1], guard)) {
-      customizer = length < 3 ? undefined : customizer;
-      length = 1;
-    }
-    object = Object(object);
-    while (++index < length) {
-      var source = sources[index];
-      if (source) {
-        assigner(object, source, index, customizer);
-      }
-    }
-    return object;
-  });
-}
-
-/**
- * Gets the "length" property value of `object`.
- *
- * **Note:** This function is used to avoid a
- * [JIT bug](https://bugs.webkit.org/show_bug.cgi?id=142792) that affects
- * Safari on at least iOS 8.1-8.3 ARM64.
- *
- * @private
- * @param {Object} object The object to query.
- * @returns {*} Returns the "length" value.
- */
-var getLength = baseProperty('length');
-
-/**
- * Checks if `value` is a valid array-like index.
- *
- * @private
- * @param {*} value The value to check.
- * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
- * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
- */
-function isIndex(value, length) {
-  length = length == null ? MAX_SAFE_INTEGER : length;
-  return !!length &&
-    (typeof value == 'number' || reIsUint.test(value)) &&
-    (value > -1 && value % 1 == 0 && value < length);
-}
-
-/**
- * Checks if the given arguments are from an iteratee call.
- *
- * @private
- * @param {*} value The potential iteratee value argument.
- * @param {*} index The potential iteratee index or key argument.
- * @param {*} object The potential iteratee object argument.
- * @returns {boolean} Returns `true` if the arguments are from an iteratee call,
- *  else `false`.
- */
-function isIterateeCall(value, index, object) {
-  if (!isObject(object)) {
-    return false;
-  }
-  var type = typeof index;
-  if (type == 'number'
-        ? (isArrayLike(object) && isIndex(index, object.length))
-        : (type == 'string' && index in object)
-      ) {
-    return eq(object[index], value);
-  }
-  return false;
-}
-
-/**
- * Performs a
- * [`SameValueZero`](http://ecma-international.org/ecma-262/6.0/#sec-samevaluezero)
- * comparison between two values to determine if they are equivalent.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to compare.
- * @param {*} other The other value to compare.
- * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
- * @example
- *
- * var object = { 'user': 'fred' };
- * var other = { 'user': 'fred' };
- *
- * _.eq(object, object);
- * // => true
- *
- * _.eq(object, other);
- * // => false
- *
- * _.eq('a', 'a');
- * // => true
- *
- * _.eq('a', Object('a'));
- * // => false
- *
- * _.eq(NaN, NaN);
- * // => true
- */
-function eq(value, other) {
-  return value === other || (value !== value && other !== other);
-}
-
-/**
- * Checks if `value` is array-like. A value is considered array-like if it's
- * not a function and has a `value.length` that's an integer greater than or
- * equal to `0` and less than or equal to `Number.MAX_SAFE_INTEGER`.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is array-like, else `false`.
- * @example
- *
- * _.isArrayLike([1, 2, 3]);
- * // => true
- *
- * _.isArrayLike(document.body.children);
- * // => true
- *
- * _.isArrayLike('abc');
- * // => true
- *
- * _.isArrayLike(_.noop);
- * // => false
- */
-function isArrayLike(value) {
-  return value != null && isLength(getLength(value)) && !isFunction(value);
-}
-
-/**
- * Checks if `value` is classified as a `Function` object.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
- * @example
- *
- * _.isFunction(_);
- * // => true
- *
- * _.isFunction(/abc/);
- * // => false
- */
-function isFunction(value) {
-  // The use of `Object#toString` avoids issues with the `typeof` operator
-  // in Safari 8 which returns 'object' for typed array and weak map constructors,
-  // and PhantomJS 1.9 which returns 'function' for `NodeList` instances.
-  var tag = isObject(value) ? objectToString.call(value) : '';
-  return tag == funcTag || tag == genTag;
-}
-
-/**
- * Checks if `value` is a valid array-like length.
- *
- * **Note:** This function is loosely based on
- * [`ToLength`](http://ecma-international.org/ecma-262/6.0/#sec-tolength).
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a valid length,
- *  else `false`.
- * @example
- *
- * _.isLength(3);
- * // => true
- *
- * _.isLength(Number.MIN_VALUE);
- * // => false
- *
- * _.isLength(Infinity);
- * // => false
- *
- * _.isLength('3');
- * // => false
- */
-function isLength(value) {
-  return typeof value == 'number' &&
-    value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER;
-}
-
-/**
- * Checks if `value` is the
- * [language type](http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-language-types)
- * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is an object, else `false`.
- * @example
- *
- * _.isObject({});
- * // => true
- *
- * _.isObject([1, 2, 3]);
- * // => true
- *
- * _.isObject(_.noop);
- * // => true
- *
- * _.isObject(null);
- * // => false
- */
-function isObject(value) {
-  var type = typeof value;
-  return !!value && (type == 'object' || type == 'function');
-}
-
-/**
- * This method is like `_.assignIn` except that it accepts `customizer`
- * which is invoked to produce the assigned values. If `customizer` returns
- * `undefined`, assignment is handled by the method instead. The `customizer`
- * is invoked with five arguments: (objValue, srcValue, key, object, source).
- *
- * **Note:** This method mutates `object`.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @alias extendWith
- * @category Object
- * @param {Object} object The destination object.
- * @param {...Object} sources The source objects.
- * @param {Function} [customizer] The function to customize assigned values.
- * @returns {Object} Returns `object`.
- * @see _.assignWith
- * @example
- *
- * function customizer(objValue, srcValue) {
- *   return _.isUndefined(objValue) ? srcValue : objValue;
- * }
- *
- * var defaults = _.partialRight(_.assignInWith, customizer);
- *
- * defaults({ 'a': 1 }, { 'b': 2 }, { 'a': 3 });
- * // => { 'a': 1, 'b': 2 }
- */
-var assignInWith = createAssigner(function(object, source, srcIndex, customizer) {
-  copyObject(source, keysIn(source), object, customizer);
-});
-
-module.exports = assignInWith;
-
-},{"lodash.keysin":11,"lodash.rest":12}],7:[function(require,module,exports){
-/**
- * lodash 4.0.6 (Custom Build) <https://lodash.com/>
  * Build: `lodash modularize exports="npm" -o ./`
  * Copyright jQuery Foundation and other contributors <https://jquery.org/>
  * Released under MIT license <https://lodash.com/license>
@@ -941,9 +512,7 @@ var FUNC_ERROR_TEXT = 'Expected a function';
 var NAN = 0 / 0;
 
 /** `Object#toString` result references. */
-var funcTag = '[object Function]',
-    genTag = '[object GeneratorFunction]',
-    symbolTag = '[object Symbol]';
+var symbolTag = '[object Symbol]';
 
 /** Used to match leading and trailing whitespace. */
 var reTrim = /^\s+|\s+$/g;
@@ -960,12 +529,21 @@ var reIsOctal = /^0o[0-7]+$/i;
 /** Built-in method references without a dependency on `root`. */
 var freeParseInt = parseInt;
 
+/** Detect free variable `global` from Node.js. */
+var freeGlobal = typeof global == 'object' && global && global.Object === Object && global;
+
+/** Detect free variable `self`. */
+var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
+
+/** Used as a reference to the global object. */
+var root = freeGlobal || freeSelf || Function('return this')();
+
 /** Used for built-in method references. */
 var objectProto = Object.prototype;
 
 /**
  * Used to resolve the
- * [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+ * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
  * of values.
  */
 var objectToString = objectProto.toString;
@@ -981,7 +559,6 @@ var nativeMax = Math.max,
  * @static
  * @memberOf _
  * @since 2.4.0
- * @type {Function}
  * @category Date
  * @returns {number} Returns the timestamp.
  * @example
@@ -989,23 +566,29 @@ var nativeMax = Math.max,
  * _.defer(function(stamp) {
  *   console.log(_.now() - stamp);
  * }, _.now());
- * // => Logs the number of milliseconds it took for the deferred function to be invoked.
+ * // => Logs the number of milliseconds it took for the deferred invocation.
  */
-var now = Date.now;
+var now = function() {
+  return root.Date.now();
+};
 
 /**
  * Creates a debounced function that delays invoking `func` until after `wait`
  * milliseconds have elapsed since the last time the debounced function was
  * invoked. The debounced function comes with a `cancel` method to cancel
  * delayed `func` invocations and a `flush` method to immediately invoke them.
- * Provide an options object to indicate whether `func` should be invoked on
- * the leading and/or trailing edge of the `wait` timeout. The `func` is invoked
- * with the last arguments provided to the debounced function. Subsequent calls
- * to the debounced function return the result of the last `func` invocation.
+ * Provide `options` to indicate whether `func` should be invoked on the
+ * leading and/or trailing edge of the `wait` timeout. The `func` is invoked
+ * with the last arguments provided to the debounced function. Subsequent
+ * calls to the debounced function return the result of the last `func`
+ * invocation.
  *
- * **Note:** If `leading` and `trailing` options are `true`, `func` is invoked
- * on the trailing edge of the timeout only if the debounced function is
- * invoked more than once during the `wait` timeout.
+ * **Note:** If `leading` and `trailing` options are `true`, `func` is
+ * invoked on the trailing edge of the timeout only if the debounced function
+ * is invoked more than once during the `wait` timeout.
+ *
+ * If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
+ * until to the next tick, similar to `setTimeout` with a timeout of `0`.
  *
  * See [David Corbacho's article](https://css-tricks.com/debouncing-throttling-explained-examples/)
  * for details over the differences between `_.debounce` and `_.throttle`.
@@ -1049,7 +632,7 @@ function debounce(func, wait, options) {
       maxWait,
       result,
       timerId,
-      lastCallTime = 0,
+      lastCallTime,
       lastInvokeTime = 0,
       leading = false,
       maxing = false,
@@ -1100,7 +683,7 @@ function debounce(func, wait, options) {
     // Either this is the first call, activity has stopped and we're at the
     // trailing edge, the system time has gone backwards and we're treating
     // it as the trailing edge, or we've hit the `maxWait` limit.
-    return (!lastCallTime || (timeSinceLastCall >= wait) ||
+    return (lastCallTime === undefined || (timeSinceLastCall >= wait) ||
       (timeSinceLastCall < 0) || (maxing && timeSinceLastInvoke >= maxWait));
   }
 
@@ -1114,7 +697,6 @@ function debounce(func, wait, options) {
   }
 
   function trailingEdge(time) {
-    clearTimeout(timerId);
     timerId = undefined;
 
     // Only invoke if we have `lastArgs` which means `func` has been
@@ -1130,8 +712,8 @@ function debounce(func, wait, options) {
     if (timerId !== undefined) {
       clearTimeout(timerId);
     }
-    lastCallTime = lastInvokeTime = 0;
-    lastArgs = lastThis = timerId = undefined;
+    lastInvokeTime = 0;
+    lastArgs = lastCallTime = lastThis = timerId = undefined;
   }
 
   function flush() {
@@ -1152,7 +734,6 @@ function debounce(func, wait, options) {
       }
       if (maxing) {
         // Handle invocations in a tight loop.
-        clearTimeout(timerId);
         timerId = setTimeout(timerExpired, wait);
         return invokeFunc(lastCallTime);
       }
@@ -1168,34 +749,8 @@ function debounce(func, wait, options) {
 }
 
 /**
- * Checks if `value` is classified as a `Function` object.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
- * @example
- *
- * _.isFunction(_);
- * // => true
- *
- * _.isFunction(/abc/);
- * // => false
- */
-function isFunction(value) {
-  // The use of `Object#toString` avoids issues with the `typeof` operator
-  // in Safari 8 which returns 'object' for typed array and weak map constructors,
-  // and PhantomJS 1.9 which returns 'function' for `NodeList` instances.
-  var tag = isObject(value) ? objectToString.call(value) : '';
-  return tag == funcTag || tag == genTag;
-}
-
-/**
  * Checks if `value` is the
- * [language type](http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-language-types)
+ * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
  * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
  *
  * @static
@@ -1259,8 +814,7 @@ function isObjectLike(value) {
  * @since 4.0.0
  * @category Lang
  * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
+ * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
  * @example
  *
  * _.isSymbol(Symbol.iterator);
@@ -1285,8 +839,8 @@ function isSymbol(value) {
  * @returns {number} Returns the number.
  * @example
  *
- * _.toNumber(3);
- * // => 3
+ * _.toNumber(3.2);
+ * // => 3.2
  *
  * _.toNumber(Number.MIN_VALUE);
  * // => 5e-324
@@ -1294,8 +848,8 @@ function isSymbol(value) {
  * _.toNumber(Infinity);
  * // => Infinity
  *
- * _.toNumber('3');
- * // => 3
+ * _.toNumber('3.2');
+ * // => 3.2
  */
 function toNumber(value) {
   if (typeof value == 'number') {
@@ -1305,7 +859,7 @@ function toNumber(value) {
     return NAN;
   }
   if (isObject(value)) {
-    var other = isFunction(value.valueOf) ? value.valueOf() : value;
+    var other = typeof value.valueOf == 'function' ? value.valueOf() : value;
     value = isObject(other) ? (other + '') : other;
   }
   if (typeof value != 'string') {
@@ -1320,84 +874,9 @@ function toNumber(value) {
 
 module.exports = debounce;
 
-},{}],8:[function(require,module,exports){
-/**
- * lodash 4.0.0 (Custom Build) <https://lodash.com/>
- * Build: `lodash modularize exports="npm" -o ./`
- * Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
- * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
- * Copyright 2009-2016 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
- * Available under MIT license <https://lodash.com/license>
- */
-var toString = require('lodash.tostring');
-
-/** Used to match HTML entities and HTML characters. */
-var reUnescapedHtml = /[&<>"'`]/g,
-    reHasUnescapedHtml = RegExp(reUnescapedHtml.source);
-
-/** Used to map characters to HTML entities. */
-var htmlEscapes = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  "'": '&#39;',
-  '`': '&#96;'
-};
-
-/**
- * Used by `_.escape` to convert characters to HTML entities.
- *
- * @private
- * @param {string} chr The matched character to escape.
- * @returns {string} Returns the escaped character.
- */
-function escapeHtmlChar(chr) {
-  return htmlEscapes[chr];
-}
-
-/**
- * Converts the characters "&", "<", ">", '"', "'", and "\`" in `string` to
- * their corresponding HTML entities.
- *
- * **Note:** No other characters are escaped. To escape additional
- * characters use a third-party library like [_he_](https://mths.be/he).
- *
- * Though the ">" character is escaped for symmetry, characters like
- * ">" and "/" don't need escaping in HTML and have no special meaning
- * unless they're part of a tag or unquoted attribute value.
- * See [Mathias Bynens's article](https://mathiasbynens.be/notes/ambiguous-ampersands)
- * (under "semi-related fun fact") for more details.
- *
- * Backticks are escaped because in IE < 9, they can break out of
- * attribute values or HTML comments. See [#59](https://html5sec.org/#59),
- * [#102](https://html5sec.org/#102), [#108](https://html5sec.org/#108), and
- * [#133](https://html5sec.org/#133) of the [HTML5 Security Cheatsheet](https://html5sec.org/)
- * for more details.
- *
- * When working with HTML you should always [quote attribute values](http://wonko.com/post/html-escaping)
- * to reduce XSS vectors.
- *
- * @static
- * @memberOf _
- * @category String
- * @param {string} [string=''] The string to escape.
- * @returns {string} Returns the escaped string.
- * @example
- *
- * _.escape('fred, barney, & pebbles');
- * // => 'fred, barney, &amp; pebbles'
- */
-function escape(string) {
-  string = toString(string);
-  return (string && reHasUnescapedHtml.test(string))
-    ? string.replace(reUnescapedHtml, escapeHtmlChar)
-    : string;
-}
-
-module.exports = escape;
-
-},{"lodash.tostring":15}],9:[function(require,module,exports){
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{}],6:[function(require,module,exports){
+(function (global){
 /**
  * lodash (Custom Build) <https://lodash.com/>
  * Build: `lodash modularize exports="npm" -o ./`
@@ -1406,8 +885,6 @@ module.exports = escape;
  * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
  * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
  */
-var keys = require('lodash.keys'),
-    root = require('lodash._root');
 
 /** Used as the size to enable large array optimizations. */
 var LARGE_ARRAY_SIZE = 200;
@@ -1454,12 +931,15 @@ var arrayBufferTag = '[object ArrayBuffer]',
 
 /**
  * Used to match `RegExp`
- * [syntax characters](http://ecma-international.org/ecma-262/6.0/#sec-patterns).
+ * [syntax characters](http://ecma-international.org/ecma-262/7.0/#sec-patterns).
  */
 var reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
 
 /** Used to detect host constructors (Safari). */
 var reIsHostCtor = /^\[object .+?Constructor\]$/;
+
+/** Used to detect unsigned integer values. */
+var reIsUint = /^(?:0|[1-9]\d*)$/;
 
 /** Used to identify `toStringTag` values of typed arrays. */
 var typedArrayTags = {};
@@ -1477,19 +957,50 @@ typedArrayTags[objectTag] = typedArrayTags[regexpTag] =
 typedArrayTags[setTag] = typedArrayTags[stringTag] =
 typedArrayTags[weakMapTag] = false;
 
+/** Detect free variable `global` from Node.js. */
+var freeGlobal = typeof global == 'object' && global && global.Object === Object && global;
+
+/** Detect free variable `self`. */
+var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
+
+/** Used as a reference to the global object. */
+var root = freeGlobal || freeSelf || Function('return this')();
+
+/** Detect free variable `exports`. */
+var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
+
+/** Detect free variable `module`. */
+var freeModule = freeExports && typeof module == 'object' && module && !module.nodeType && module;
+
+/** Detect the popular CommonJS extension `module.exports`. */
+var moduleExports = freeModule && freeModule.exports === freeExports;
+
+/** Detect free variable `process` from Node.js. */
+var freeProcess = moduleExports && freeGlobal.process;
+
+/** Used to access faster Node.js helpers. */
+var nodeUtil = (function() {
+  try {
+    return freeProcess && freeProcess.binding('util');
+  } catch (e) {}
+}());
+
+/* Node.js helper references. */
+var nodeIsTypedArray = nodeUtil && nodeUtil.isTypedArray;
+
 /**
  * A specialized version of `_.some` for arrays without support for iteratee
  * shorthands.
  *
  * @private
- * @param {Array} array The array to iterate over.
+ * @param {Array} [array] The array to iterate over.
  * @param {Function} predicate The function invoked per iteration.
  * @returns {boolean} Returns `true` if any element passes the predicate check,
  *  else `false`.
  */
 function arraySome(array, predicate) {
   var index = -1,
-      length = array.length;
+      length = array ? array.length : 0;
 
   while (++index < length) {
     if (predicate(array[index], index, array)) {
@@ -1497,6 +1008,50 @@ function arraySome(array, predicate) {
     }
   }
   return false;
+}
+
+/**
+ * The base implementation of `_.times` without support for iteratee shorthands
+ * or max array length checks.
+ *
+ * @private
+ * @param {number} n The number of times to invoke `iteratee`.
+ * @param {Function} iteratee The function invoked per iteration.
+ * @returns {Array} Returns the array of results.
+ */
+function baseTimes(n, iteratee) {
+  var index = -1,
+      result = Array(n);
+
+  while (++index < n) {
+    result[index] = iteratee(index);
+  }
+  return result;
+}
+
+/**
+ * The base implementation of `_.unary` without support for storing metadata.
+ *
+ * @private
+ * @param {Function} func The function to cap arguments for.
+ * @returns {Function} Returns the new capped function.
+ */
+function baseUnary(func) {
+  return function(value) {
+    return func(value);
+  };
+}
+
+/**
+ * Gets the value at `key` of `object`.
+ *
+ * @private
+ * @param {Object} [object] The object to query.
+ * @param {string} key The key of the property to get.
+ * @returns {*} Returns the property value.
+ */
+function getValue(object, key) {
+  return object == null ? undefined : object[key];
 }
 
 /**
@@ -1536,6 +1091,20 @@ function mapToArray(map) {
 }
 
 /**
+ * Creates a unary function that invokes `func` with its argument transformed.
+ *
+ * @private
+ * @param {Function} func The function to wrap.
+ * @param {Function} transform The argument transform.
+ * @returns {Function} Returns the new function.
+ */
+function overArg(func, transform) {
+  return function(arg) {
+    return func(transform(arg));
+  };
+}
+
+/**
  * Converts `set` to an array of its values.
  *
  * @private
@@ -1554,17 +1123,27 @@ function setToArray(set) {
 
 /** Used for built-in method references. */
 var arrayProto = Array.prototype,
+    funcProto = Function.prototype,
     objectProto = Object.prototype;
 
+/** Used to detect overreaching core-js shims. */
+var coreJsData = root['__core-js_shared__'];
+
+/** Used to detect methods masquerading as native. */
+var maskSrcKey = (function() {
+  var uid = /[^.]+$/.exec(coreJsData && coreJsData.keys && coreJsData.keys.IE_PROTO || '');
+  return uid ? ('Symbol(src)_1.' + uid) : '';
+}());
+
 /** Used to resolve the decompiled source of functions. */
-var funcToString = Function.prototype.toString;
+var funcToString = funcProto.toString;
 
 /** Used to check objects for own properties. */
 var hasOwnProperty = objectProto.hasOwnProperty;
 
 /**
  * Used to resolve the
- * [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+ * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
  * of values.
  */
 var objectToString = objectProto.toString;
@@ -1578,10 +1157,11 @@ var reIsNative = RegExp('^' +
 /** Built-in value references. */
 var Symbol = root.Symbol,
     Uint8Array = root.Uint8Array,
+    propertyIsEnumerable = objectProto.propertyIsEnumerable,
     splice = arrayProto.splice;
 
 /* Built-in method references for those with the same name as other `lodash` methods. */
-var nativeGetPrototype = Object.getPrototypeOf;
+var nativeKeys = overArg(Object.keys, Object);
 
 /* Built-in method references that are verified to be native. */
 var DataView = getNative(root, 'DataView'),
@@ -2029,8 +1609,13 @@ function stackHas(key) {
  */
 function stackSet(key, value) {
   var cache = this.__data__;
-  if (cache instanceof ListCache && cache.__data__.length == LARGE_ARRAY_SIZE) {
-    cache = this.__data__ = new MapCache(cache.__data__);
+  if (cache instanceof ListCache) {
+    var pairs = cache.__data__;
+    if (!Map || (pairs.length < LARGE_ARRAY_SIZE - 1)) {
+      pairs.push([key, value]);
+      return this;
+    }
+    cache = this.__data__ = new MapCache(pairs);
   }
   cache.set(key, value);
   return this;
@@ -2044,10 +1629,37 @@ Stack.prototype.has = stackHas;
 Stack.prototype.set = stackSet;
 
 /**
+ * Creates an array of the enumerable property names of the array-like `value`.
+ *
+ * @private
+ * @param {*} value The value to query.
+ * @param {boolean} inherited Specify returning inherited property names.
+ * @returns {Array} Returns the array of property names.
+ */
+function arrayLikeKeys(value, inherited) {
+  // Safari 8.1 makes `arguments.callee` enumerable in strict mode.
+  // Safari 9 makes `arguments.length` enumerable in strict mode.
+  var result = (isArray(value) || isArguments(value))
+    ? baseTimes(value.length, String)
+    : [];
+
+  var length = result.length,
+      skipIndexes = !!length;
+
+  for (var key in value) {
+    if ((inherited || hasOwnProperty.call(value, key)) &&
+        !(skipIndexes && (key == 'length' || isIndex(key, length)))) {
+      result.push(key);
+    }
+  }
+  return result;
+}
+
+/**
  * Gets the index at which the `key` is found in `array` of key-value pairs.
  *
  * @private
- * @param {Array} array The array to search.
+ * @param {Array} array The array to inspect.
  * @param {*} key The key to search for.
  * @returns {number} Returns the index of the matched value, else `-1`.
  */
@@ -2062,19 +1674,14 @@ function assocIndexOf(array, key) {
 }
 
 /**
- * The base implementation of `_.has` without support for deep paths.
+ * The base implementation of `getTag`.
  *
  * @private
- * @param {Object} object The object to query.
- * @param {Array|string} key The key to check.
- * @returns {boolean} Returns `true` if `key` exists, else `false`.
+ * @param {*} value The value to query.
+ * @returns {string} Returns the `toStringTag`.
  */
-function baseHas(object, key) {
-  // Avoid a bug in IE 10-11 where objects with a [[Prototype]] of `null`,
-  // that are composed entirely of index properties, return `false` for
-  // `hasOwnProperty` checks of them.
-  return hasOwnProperty.call(object, key) ||
-    (typeof object == 'object' && key in object && getPrototype(object) === null);
+function baseGetTag(value) {
+  return objectToString.call(value);
 }
 
 /**
@@ -2161,6 +1768,54 @@ function baseIsEqualDeep(object, other, equalFunc, customizer, bitmask, stack) {
 }
 
 /**
+ * The base implementation of `_.isNative` without bad shim checks.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a native function,
+ *  else `false`.
+ */
+function baseIsNative(value) {
+  if (!isObject(value) || isMasked(value)) {
+    return false;
+  }
+  var pattern = (isFunction(value) || isHostObject(value)) ? reIsNative : reIsHostCtor;
+  return pattern.test(toSource(value));
+}
+
+/**
+ * The base implementation of `_.isTypedArray` without Node.js optimizations.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a typed array, else `false`.
+ */
+function baseIsTypedArray(value) {
+  return isObjectLike(value) &&
+    isLength(value.length) && !!typedArrayTags[objectToString.call(value)];
+}
+
+/**
+ * The base implementation of `_.keys` which doesn't treat sparse arrays as dense.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @returns {Array} Returns the array of property names.
+ */
+function baseKeys(object) {
+  if (!isPrototype(object)) {
+    return nativeKeys(object);
+  }
+  var result = [];
+  for (var key in Object(object)) {
+    if (hasOwnProperty.call(object, key) && key != 'constructor') {
+      result.push(key);
+    }
+  }
+  return result;
+}
+
+/**
  * A specialized version of `baseIsEqualDeep` for arrays with support for
  * partial deep comparisons.
  *
@@ -2184,7 +1839,7 @@ function equalArrays(array, other, equalFunc, customizer, bitmask, stack) {
   }
   // Assume cyclic values are equal.
   var stacked = stack.get(array);
-  if (stacked) {
+  if (stacked && stack.get(other)) {
     return stacked == other;
   }
   var index = -1,
@@ -2192,6 +1847,7 @@ function equalArrays(array, other, equalFunc, customizer, bitmask, stack) {
       seen = (bitmask & UNORDERED_COMPARE_FLAG) ? new SetCache : undefined;
 
   stack.set(array, other);
+  stack.set(other, array);
 
   // Ignore non-index properties.
   while (++index < arrLength) {
@@ -2230,6 +1886,7 @@ function equalArrays(array, other, equalFunc, customizer, bitmask, stack) {
     }
   }
   stack['delete'](array);
+  stack['delete'](other);
   return result;
 }
 
@@ -2270,22 +1927,18 @@ function equalByTag(object, other, tag, equalFunc, customizer, bitmask, stack) {
 
     case boolTag:
     case dateTag:
-      // Coerce dates and booleans to numbers, dates to milliseconds and
-      // booleans to `1` or `0` treating invalid dates coerced to `NaN` as
-      // not equal.
-      return +object == +other;
+    case numberTag:
+      // Coerce booleans to `1` or `0` and dates to milliseconds.
+      // Invalid dates are coerced to `NaN`.
+      return eq(+object, +other);
 
     case errorTag:
       return object.name == other.name && object.message == other.message;
 
-    case numberTag:
-      // Treat `NaN` vs. `NaN` as equal.
-      return (object != +object) ? other != +other : object == +other;
-
     case regexpTag:
     case stringTag:
       // Coerce regexes to strings and treat strings, primitives and objects,
-      // as equal. See http://www.ecma-international.org/ecma-262/6.0/#sec-regexp.prototype.tostring
+      // as equal. See http://www.ecma-international.org/ecma-262/7.0/#sec-regexp.prototype.tostring
       // for more details.
       return object == (other + '');
 
@@ -2305,10 +1958,12 @@ function equalByTag(object, other, tag, equalFunc, customizer, bitmask, stack) {
         return stacked == other;
       }
       bitmask |= UNORDERED_COMPARE_FLAG;
-      stack.set(object, other);
 
       // Recursively compare objects (susceptible to call stack limits).
-      return equalArrays(convert(object), convert(other), equalFunc, customizer, bitmask, stack);
+      stack.set(object, other);
+      var result = equalArrays(convert(object), convert(other), equalFunc, customizer, bitmask, stack);
+      stack['delete'](object);
+      return result;
 
     case symbolTag:
       if (symbolValueOf) {
@@ -2345,17 +2000,18 @@ function equalObjects(object, other, equalFunc, customizer, bitmask, stack) {
   var index = objLength;
   while (index--) {
     var key = objProps[index];
-    if (!(isPartial ? key in other : baseHas(other, key))) {
+    if (!(isPartial ? key in other : hasOwnProperty.call(other, key))) {
       return false;
     }
   }
   // Assume cyclic values are equal.
   var stacked = stack.get(object);
-  if (stacked) {
+  if (stacked && stack.get(other)) {
     return stacked == other;
   }
   var result = true;
   stack.set(object, other);
+  stack.set(other, object);
 
   var skipCtor = isPartial;
   while (++index < objLength) {
@@ -2391,6 +2047,7 @@ function equalObjects(object, other, equalFunc, customizer, bitmask, stack) {
     }
   }
   stack['delete'](object);
+  stack['delete'](other);
   return result;
 }
 
@@ -2418,19 +2075,8 @@ function getMapData(map, key) {
  * @returns {*} Returns the function if it's native, else `undefined`.
  */
 function getNative(object, key) {
-  var value = object[key];
-  return isNative(value) ? value : undefined;
-}
-
-/**
- * Gets the `[[Prototype]]` of `value`.
- *
- * @private
- * @param {*} value The value to query.
- * @returns {null|Object} Returns the `[[Prototype]]`.
- */
-function getPrototype(value) {
-  return nativeGetPrototype(Object(value));
+  var value = getValue(object, key);
+  return baseIsNative(value) ? value : undefined;
 }
 
 /**
@@ -2440,12 +2086,10 @@ function getPrototype(value) {
  * @param {*} value The value to query.
  * @returns {string} Returns the `toStringTag`.
  */
-function getTag(value) {
-  return objectToString.call(value);
-}
+var getTag = baseGetTag;
 
 // Fallback for data views, maps, sets, and weak maps in IE 11,
-// for data views in Edge, and promises in Node.js.
+// for data views in Edge < 14, and promises in Node.js.
 if ((DataView && getTag(new DataView(new ArrayBuffer(1))) != dataViewTag) ||
     (Map && getTag(new Map) != mapTag) ||
     (Promise && getTag(Promise.resolve()) != promiseTag) ||
@@ -2470,6 +2114,21 @@ if ((DataView && getTag(new DataView(new ArrayBuffer(1))) != dataViewTag) ||
 }
 
 /**
+ * Checks if `value` is a valid array-like index.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
+ * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
+ */
+function isIndex(value, length) {
+  length = length == null ? MAX_SAFE_INTEGER : length;
+  return !!length &&
+    (typeof value == 'number' || reIsUint.test(value)) &&
+    (value > -1 && value % 1 == 0 && value < length);
+}
+
+/**
  * Checks if `value` is suitable for use as unique object key.
  *
  * @private
@@ -2481,6 +2140,31 @@ function isKeyable(value) {
   return (type == 'string' || type == 'number' || type == 'symbol' || type == 'boolean')
     ? (value !== '__proto__')
     : (value === null);
+}
+
+/**
+ * Checks if `func` has its source masked.
+ *
+ * @private
+ * @param {Function} func The function to check.
+ * @returns {boolean} Returns `true` if `func` is masked, else `false`.
+ */
+function isMasked(func) {
+  return !!maskSrcKey && (maskSrcKey in func);
+}
+
+/**
+ * Checks if `value` is likely a prototype object.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a prototype, else `false`.
+ */
+function isPrototype(value) {
+  var Ctor = value && value.constructor,
+      proto = (typeof Ctor == 'function' && Ctor.prototype) || objectProto;
+
+  return value === proto;
 }
 
 /**
@@ -2504,7 +2188,7 @@ function toSource(func) {
 
 /**
  * Performs a
- * [`SameValueZero`](http://ecma-international.org/ecma-262/6.0/#sec-samevaluezero)
+ * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
  * comparison between two values to determine if they are equivalent.
  *
  * @static
@@ -2516,8 +2200,8 @@ function toSource(func) {
  * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
  * @example
  *
- * var object = { 'user': 'fred' };
- * var other = { 'user': 'fred' };
+ * var object = { 'a': 1 };
+ * var other = { 'a': 1 };
  *
  * _.eq(object, object);
  * // => true
@@ -2539,405 +2223,6 @@ function eq(value, other) {
 }
 
 /**
- * Checks if `value` is classified as an `Array` object.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @type {Function}
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
- * @example
- *
- * _.isArray([1, 2, 3]);
- * // => true
- *
- * _.isArray(document.body.children);
- * // => false
- *
- * _.isArray('abc');
- * // => false
- *
- * _.isArray(_.noop);
- * // => false
- */
-var isArray = Array.isArray;
-
-/**
- * Performs a deep comparison between two values to determine if they are
- * equivalent.
- *
- * **Note:** This method supports comparing arrays, array buffers, booleans,
- * date objects, error objects, maps, numbers, `Object` objects, regexes,
- * sets, strings, symbols, and typed arrays. `Object` objects are compared
- * by their own, not inherited, enumerable properties. Functions and DOM
- * nodes are **not** supported.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to compare.
- * @param {*} other The other value to compare.
- * @returns {boolean} Returns `true` if the values are equivalent,
- *  else `false`.
- * @example
- *
- * var object = { 'user': 'fred' };
- * var other = { 'user': 'fred' };
- *
- * _.isEqual(object, other);
- * // => true
- *
- * object === other;
- * // => false
- */
-function isEqual(value, other) {
-  return baseIsEqual(value, other);
-}
-
-/**
- * Checks if `value` is classified as a `Function` object.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
- * @example
- *
- * _.isFunction(_);
- * // => true
- *
- * _.isFunction(/abc/);
- * // => false
- */
-function isFunction(value) {
-  // The use of `Object#toString` avoids issues with the `typeof` operator
-  // in Safari 8 which returns 'object' for typed array and weak map constructors,
-  // and PhantomJS 1.9 which returns 'function' for `NodeList` instances.
-  var tag = isObject(value) ? objectToString.call(value) : '';
-  return tag == funcTag || tag == genTag;
-}
-
-/**
- * Checks if `value` is a valid array-like length.
- *
- * **Note:** This function is loosely based on
- * [`ToLength`](http://ecma-international.org/ecma-262/6.0/#sec-tolength).
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a valid length,
- *  else `false`.
- * @example
- *
- * _.isLength(3);
- * // => true
- *
- * _.isLength(Number.MIN_VALUE);
- * // => false
- *
- * _.isLength(Infinity);
- * // => false
- *
- * _.isLength('3');
- * // => false
- */
-function isLength(value) {
-  return typeof value == 'number' &&
-    value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER;
-}
-
-/**
- * Checks if `value` is the
- * [language type](http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-language-types)
- * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is an object, else `false`.
- * @example
- *
- * _.isObject({});
- * // => true
- *
- * _.isObject([1, 2, 3]);
- * // => true
- *
- * _.isObject(_.noop);
- * // => true
- *
- * _.isObject(null);
- * // => false
- */
-function isObject(value) {
-  var type = typeof value;
-  return !!value && (type == 'object' || type == 'function');
-}
-
-/**
- * Checks if `value` is object-like. A value is object-like if it's not `null`
- * and has a `typeof` result of "object".
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
- * @example
- *
- * _.isObjectLike({});
- * // => true
- *
- * _.isObjectLike([1, 2, 3]);
- * // => true
- *
- * _.isObjectLike(_.noop);
- * // => false
- *
- * _.isObjectLike(null);
- * // => false
- */
-function isObjectLike(value) {
-  return !!value && typeof value == 'object';
-}
-
-/**
- * Checks if `value` is a native function.
- *
- * @static
- * @memberOf _
- * @since 3.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a native function,
- *  else `false`.
- * @example
- *
- * _.isNative(Array.prototype.push);
- * // => true
- *
- * _.isNative(_);
- * // => false
- */
-function isNative(value) {
-  if (!isObject(value)) {
-    return false;
-  }
-  var pattern = (isFunction(value) || isHostObject(value)) ? reIsNative : reIsHostCtor;
-  return pattern.test(toSource(value));
-}
-
-/**
- * Checks if `value` is classified as a typed array.
- *
- * @static
- * @memberOf _
- * @since 3.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
- * @example
- *
- * _.isTypedArray(new Uint8Array);
- * // => true
- *
- * _.isTypedArray([]);
- * // => false
- */
-function isTypedArray(value) {
-  return isObjectLike(value) &&
-    isLength(value.length) && !!typedArrayTags[objectToString.call(value)];
-}
-
-module.exports = isEqual;
-
-},{"lodash._root":5,"lodash.keys":10}],10:[function(require,module,exports){
-/**
- * lodash (Custom Build) <https://lodash.com/>
- * Build: `lodash modularize exports="npm" -o ./`
- * Copyright jQuery Foundation and other contributors <https://jquery.org/>
- * Released under MIT license <https://lodash.com/license>
- * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
- * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
- */
-
-/** Used as references for various `Number` constants. */
-var MAX_SAFE_INTEGER = 9007199254740991;
-
-/** `Object#toString` result references. */
-var argsTag = '[object Arguments]',
-    funcTag = '[object Function]',
-    genTag = '[object GeneratorFunction]',
-    stringTag = '[object String]';
-
-/** Used to detect unsigned integer values. */
-var reIsUint = /^(?:0|[1-9]\d*)$/;
-
-/**
- * The base implementation of `_.times` without support for iteratee shorthands
- * or max array length checks.
- *
- * @private
- * @param {number} n The number of times to invoke `iteratee`.
- * @param {Function} iteratee The function invoked per iteration.
- * @returns {Array} Returns the array of results.
- */
-function baseTimes(n, iteratee) {
-  var index = -1,
-      result = Array(n);
-
-  while (++index < n) {
-    result[index] = iteratee(index);
-  }
-  return result;
-}
-
-/** Used for built-in method references. */
-var objectProto = Object.prototype;
-
-/** Used to check objects for own properties. */
-var hasOwnProperty = objectProto.hasOwnProperty;
-
-/**
- * Used to resolve the
- * [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
- * of values.
- */
-var objectToString = objectProto.toString;
-
-/** Built-in value references. */
-var propertyIsEnumerable = objectProto.propertyIsEnumerable;
-
-/* Built-in method references for those with the same name as other `lodash` methods. */
-var nativeGetPrototype = Object.getPrototypeOf,
-    nativeKeys = Object.keys;
-
-/**
- * The base implementation of `_.has` without support for deep paths.
- *
- * @private
- * @param {Object} object The object to query.
- * @param {Array|string} key The key to check.
- * @returns {boolean} Returns `true` if `key` exists, else `false`.
- */
-function baseHas(object, key) {
-  // Avoid a bug in IE 10-11 where objects with a [[Prototype]] of `null`,
-  // that are composed entirely of index properties, return `false` for
-  // `hasOwnProperty` checks of them.
-  return hasOwnProperty.call(object, key) ||
-    (typeof object == 'object' && key in object && getPrototype(object) === null);
-}
-
-/**
- * The base implementation of `_.keys` which doesn't skip the constructor
- * property of prototypes or treat sparse arrays as dense.
- *
- * @private
- * @param {Object} object The object to query.
- * @returns {Array} Returns the array of property names.
- */
-function baseKeys(object) {
-  return nativeKeys(Object(object));
-}
-
-/**
- * The base implementation of `_.property` without support for deep paths.
- *
- * @private
- * @param {string} key The key of the property to get.
- * @returns {Function} Returns the new accessor function.
- */
-function baseProperty(key) {
-  return function(object) {
-    return object == null ? undefined : object[key];
-  };
-}
-
-/**
- * Gets the "length" property value of `object`.
- *
- * **Note:** This function is used to avoid a
- * [JIT bug](https://bugs.webkit.org/show_bug.cgi?id=142792) that affects
- * Safari on at least iOS 8.1-8.3 ARM64.
- *
- * @private
- * @param {Object} object The object to query.
- * @returns {*} Returns the "length" value.
- */
-var getLength = baseProperty('length');
-
-/**
- * Gets the `[[Prototype]]` of `value`.
- *
- * @private
- * @param {*} value The value to query.
- * @returns {null|Object} Returns the `[[Prototype]]`.
- */
-function getPrototype(value) {
-  return nativeGetPrototype(Object(value));
-}
-
-/**
- * Creates an array of index keys for `object` values of arrays,
- * `arguments` objects, and strings, otherwise `null` is returned.
- *
- * @private
- * @param {Object} object The object to query.
- * @returns {Array|null} Returns index keys, else `null`.
- */
-function indexKeys(object) {
-  var length = object ? object.length : undefined;
-  if (isLength(length) &&
-      (isArray(object) || isString(object) || isArguments(object))) {
-    return baseTimes(length, String);
-  }
-  return null;
-}
-
-/**
- * Checks if `value` is a valid array-like index.
- *
- * @private
- * @param {*} value The value to check.
- * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
- * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
- */
-function isIndex(value, length) {
-  length = length == null ? MAX_SAFE_INTEGER : length;
-  return !!length &&
-    (typeof value == 'number' || reIsUint.test(value)) &&
-    (value > -1 && value % 1 == 0 && value < length);
-}
-
-/**
- * Checks if `value` is likely a prototype object.
- *
- * @private
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a prototype, else `false`.
- */
-function isPrototype(value) {
-  var Ctor = value && value.constructor,
-      proto = (typeof Ctor == 'function' && Ctor.prototype) || objectProto;
-
-  return value === proto;
-}
-
-/**
  * Checks if `value` is likely an `arguments` object.
  *
  * @static
@@ -2945,7 +2230,7 @@ function isPrototype(value) {
  * @since 0.1.0
  * @category Lang
  * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
+ * @returns {boolean} Returns `true` if `value` is an `arguments` object,
  *  else `false`.
  * @example
  *
@@ -2956,7 +2241,7 @@ function isPrototype(value) {
  * // => false
  */
 function isArguments(value) {
-  // Safari 8.1 incorrectly makes `arguments.callee` enumerable in strict mode.
+  // Safari 8.1 makes `arguments.callee` enumerable in strict mode.
   return isArrayLikeObject(value) && hasOwnProperty.call(value, 'callee') &&
     (!propertyIsEnumerable.call(value, 'callee') || objectToString.call(value) == argsTag);
 }
@@ -2967,11 +2252,9 @@ function isArguments(value) {
  * @static
  * @memberOf _
  * @since 0.1.0
- * @type {Function}
  * @category Lang
  * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
+ * @returns {boolean} Returns `true` if `value` is an array, else `false`.
  * @example
  *
  * _.isArray([1, 2, 3]);
@@ -3014,7 +2297,7 @@ var isArray = Array.isArray;
  * // => false
  */
 function isArrayLike(value) {
-  return value != null && isLength(getLength(value)) && !isFunction(value);
+  return value != null && isLength(value.length) && !isFunction(value);
 }
 
 /**
@@ -3047,6 +2330,38 @@ function isArrayLikeObject(value) {
 }
 
 /**
+ * Performs a deep comparison between two values to determine if they are
+ * equivalent.
+ *
+ * **Note:** This method supports comparing arrays, array buffers, booleans,
+ * date objects, error objects, maps, numbers, `Object` objects, regexes,
+ * sets, strings, symbols, and typed arrays. `Object` objects are compared
+ * by their own, not inherited, enumerable properties. Functions and DOM
+ * nodes are **not** supported.
+ *
+ * @static
+ * @memberOf _
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to compare.
+ * @param {*} other The other value to compare.
+ * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
+ * @example
+ *
+ * var object = { 'a': 1 };
+ * var other = { 'a': 1 };
+ *
+ * _.isEqual(object, other);
+ * // => true
+ *
+ * object === other;
+ * // => false
+ */
+function isEqual(value, other) {
+  return baseIsEqual(value, other);
+}
+
+/**
  * Checks if `value` is classified as a `Function` object.
  *
  * @static
@@ -3054,8 +2369,7 @@ function isArrayLikeObject(value) {
  * @since 0.1.0
  * @category Lang
  * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
+ * @returns {boolean} Returns `true` if `value` is a function, else `false`.
  * @example
  *
  * _.isFunction(_);
@@ -3066,8 +2380,7 @@ function isArrayLikeObject(value) {
  */
 function isFunction(value) {
   // The use of `Object#toString` avoids issues with the `typeof` operator
-  // in Safari 8 which returns 'object' for typed array and weak map constructors,
-  // and PhantomJS 1.9 which returns 'function' for `NodeList` instances.
+  // in Safari 8-9 which returns 'object' for typed array and other constructors.
   var tag = isObject(value) ? objectToString.call(value) : '';
   return tag == funcTag || tag == genTag;
 }
@@ -3075,16 +2388,15 @@ function isFunction(value) {
 /**
  * Checks if `value` is a valid array-like length.
  *
- * **Note:** This function is loosely based on
- * [`ToLength`](http://ecma-international.org/ecma-262/6.0/#sec-tolength).
+ * **Note:** This method is loosely based on
+ * [`ToLength`](http://ecma-international.org/ecma-262/7.0/#sec-tolength).
  *
  * @static
  * @memberOf _
  * @since 4.0.0
  * @category Lang
  * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a valid length,
- *  else `false`.
+ * @returns {boolean} Returns `true` if `value` is a valid length, else `false`.
  * @example
  *
  * _.isLength(3);
@@ -3106,7 +2418,7 @@ function isLength(value) {
 
 /**
  * Checks if `value` is the
- * [language type](http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-language-types)
+ * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
  * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
  *
  * @static
@@ -3163,33 +2475,29 @@ function isObjectLike(value) {
 }
 
 /**
- * Checks if `value` is classified as a `String` primitive or object.
+ * Checks if `value` is classified as a typed array.
  *
  * @static
- * @since 0.1.0
  * @memberOf _
+ * @since 3.0.0
  * @category Lang
  * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
+ * @returns {boolean} Returns `true` if `value` is a typed array, else `false`.
  * @example
  *
- * _.isString('abc');
+ * _.isTypedArray(new Uint8Array);
  * // => true
  *
- * _.isString(1);
+ * _.isTypedArray([]);
  * // => false
  */
-function isString(value) {
-  return typeof value == 'string' ||
-    (!isArray(value) && isObjectLike(value) && objectToString.call(value) == stringTag);
-}
+var isTypedArray = nodeIsTypedArray ? baseUnary(nodeIsTypedArray) : baseIsTypedArray;
 
 /**
  * Creates an array of the own enumerable property names of `object`.
  *
  * **Note:** Non-object values are coerced to objects. See the
- * [ES spec](http://ecma-international.org/ecma-262/6.0/#sec-object.keys)
+ * [ES spec](http://ecma-international.org/ecma-262/7.0/#sec-object.keys)
  * for more details.
  *
  * @static
@@ -3214,28 +2522,13 @@ function isString(value) {
  * // => ['0', '1']
  */
 function keys(object) {
-  var isProto = isPrototype(object);
-  if (!(isProto || isArrayLike(object))) {
-    return baseKeys(object);
-  }
-  var indexes = indexKeys(object),
-      skipIndexes = !!indexes,
-      result = indexes || [],
-      length = result.length;
-
-  for (var key in object) {
-    if (baseHas(object, key) &&
-        !(skipIndexes && (key == 'length' || isIndex(key, length))) &&
-        !(isProto && key == 'constructor')) {
-      result.push(key);
-    }
-  }
-  return result;
+  return isArrayLike(object) ? arrayLikeKeys(object) : baseKeys(object);
 }
 
-module.exports = keys;
+module.exports = isEqual;
 
-},{}],11:[function(require,module,exports){
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{}],7:[function(require,module,exports){
 (function (global){
 /**
  * lodash (Custom Build) <https://lodash.com/>
@@ -3245,56 +2538,98 @@ module.exports = keys;
  * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
  * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
  */
+var reInterpolate = require('lodash._reinterpolate'),
+    templateSettings = require('lodash.templatesettings');
 
 /** Used as references for various `Number` constants. */
-var MAX_SAFE_INTEGER = 9007199254740991;
+var INFINITY = 1 / 0,
+    MAX_SAFE_INTEGER = 9007199254740991;
 
 /** `Object#toString` result references. */
 var argsTag = '[object Arguments]',
+    errorTag = '[object Error]',
     funcTag = '[object Function]',
     genTag = '[object GeneratorFunction]',
-    stringTag = '[object String]';
+    symbolTag = '[object Symbol]';
+
+/** Used to match empty string literals in compiled template source. */
+var reEmptyStringLeading = /\b__p \+= '';/g,
+    reEmptyStringMiddle = /\b(__p \+=) '' \+/g,
+    reEmptyStringTrailing = /(__e\(.*?\)|\b__t\)) \+\n'';/g;
+
+/**
+ * Used to match
+ * [ES template delimiters](http://ecma-international.org/ecma-262/7.0/#sec-template-literal-lexical-components).
+ */
+var reEsTemplate = /\$\{([^\\}]*(?:\\.[^\\}]*)*)\}/g;
 
 /** Used to detect unsigned integer values. */
 var reIsUint = /^(?:0|[1-9]\d*)$/;
 
-/** Used to determine if values are of the language type `Object`. */
-var objectTypes = {
-  'function': true,
-  'object': true
+/** Used to ensure capturing order of template delimiters. */
+var reNoMatch = /($^)/;
+
+/** Used to match unescaped characters in compiled string literals. */
+var reUnescapedString = /['\n\r\u2028\u2029\\]/g;
+
+/** Used to escape characters for inclusion in compiled string literals. */
+var stringEscapes = {
+  '\\': '\\',
+  "'": "'",
+  '\n': 'n',
+  '\r': 'r',
+  '\u2028': 'u2028',
+  '\u2029': 'u2029'
 };
 
-/** Detect free variable `exports`. */
-var freeExports = (objectTypes[typeof exports] && exports && !exports.nodeType)
-  ? exports
-  : undefined;
-
-/** Detect free variable `module`. */
-var freeModule = (objectTypes[typeof module] && module && !module.nodeType)
-  ? module
-  : undefined;
-
 /** Detect free variable `global` from Node.js. */
-var freeGlobal = checkGlobal(freeExports && freeModule && typeof global == 'object' && global);
+var freeGlobal = typeof global == 'object' && global && global.Object === Object && global;
 
 /** Detect free variable `self`. */
-var freeSelf = checkGlobal(objectTypes[typeof self] && self);
+var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
 
-/** Detect free variable `window`. */
-var freeWindow = checkGlobal(objectTypes[typeof window] && window);
-
-/** Detect `this` as the global object. */
-var thisGlobal = checkGlobal(objectTypes[typeof this] && this);
+/** Used as a reference to the global object. */
+var root = freeGlobal || freeSelf || Function('return this')();
 
 /**
- * Used as a reference to the global object.
+ * A faster alternative to `Function#apply`, this function invokes `func`
+ * with the `this` binding of `thisArg` and the arguments of `args`.
  *
- * The `this` value is used if it's the global object to avoid Greasemonkey's
- * restricted `window` object, otherwise the `window` object is used.
+ * @private
+ * @param {Function} func The function to invoke.
+ * @param {*} thisArg The `this` binding of `func`.
+ * @param {Array} args The arguments to invoke `func` with.
+ * @returns {*} Returns the result of `func`.
  */
-var root = freeGlobal ||
-  ((freeWindow !== (thisGlobal && thisGlobal.window)) && freeWindow) ||
-    freeSelf || thisGlobal || Function('return this')();
+function apply(func, thisArg, args) {
+  switch (args.length) {
+    case 0: return func.call(thisArg);
+    case 1: return func.call(thisArg, args[0]);
+    case 2: return func.call(thisArg, args[0], args[1]);
+    case 3: return func.call(thisArg, args[0], args[1], args[2]);
+  }
+  return func.apply(thisArg, args);
+}
+
+/**
+ * A specialized version of `_.map` for arrays without support for iteratee
+ * shorthands.
+ *
+ * @private
+ * @param {Array} [array] The array to iterate over.
+ * @param {Function} iteratee The function invoked per iteration.
+ * @returns {Array} Returns the new mapped array.
+ */
+function arrayMap(array, iteratee) {
+  var index = -1,
+      length = array ? array.length : 0,
+      result = Array(length);
+
+  while (++index < length) {
+    result[index] = iteratee(array[index], index, array);
+  }
+  return result;
+}
 
 /**
  * The base implementation of `_.times` without support for iteratee shorthands
@@ -3316,31 +2651,44 @@ function baseTimes(n, iteratee) {
 }
 
 /**
- * Checks if `value` is a global object.
+ * The base implementation of `_.values` and `_.valuesIn` which creates an
+ * array of `object` property values corresponding to the property names
+ * of `props`.
  *
  * @private
- * @param {*} value The value to check.
- * @returns {null|Object} Returns `value` if it's a global object, else `null`.
+ * @param {Object} object The object to query.
+ * @param {Array} props The property names to get values for.
+ * @returns {Object} Returns the array of property values.
  */
-function checkGlobal(value) {
-  return (value && value.Object === Object) ? value : null;
+function baseValues(object, props) {
+  return arrayMap(props, function(key) {
+    return object[key];
+  });
 }
 
 /**
- * Converts `iterator` to an array.
+ * Used by `_.template` to escape characters for inclusion in compiled string literals.
  *
  * @private
- * @param {Object} iterator The iterator to convert.
- * @returns {Array} Returns the converted array.
+ * @param {string} chr The matched character to escape.
+ * @returns {string} Returns the escaped character.
  */
-function iteratorToArray(iterator) {
-  var data,
-      result = [];
+function escapeStringChar(chr) {
+  return '\\' + stringEscapes[chr];
+}
 
-  while (!(data = iterator.next()).done) {
-    result.push(data.value);
-  }
-  return result;
+/**
+ * Creates a unary function that invokes `func` with its argument transformed.
+ *
+ * @private
+ * @param {Function} func The function to wrap.
+ * @param {Function} transform The argument transform.
+ * @returns {Function} Returns the new function.
+ */
+function overArg(func, transform) {
+  return function(arg) {
+    return func(transform(arg));
+  };
 }
 
 /** Used for built-in method references. */
@@ -3351,82 +2699,236 @@ var hasOwnProperty = objectProto.hasOwnProperty;
 
 /**
  * Used to resolve the
- * [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+ * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
  * of values.
  */
 var objectToString = objectProto.toString;
 
 /** Built-in value references. */
-var Reflect = root.Reflect,
-    enumerate = Reflect ? Reflect.enumerate : undefined,
+var Symbol = root.Symbol,
     propertyIsEnumerable = objectProto.propertyIsEnumerable;
 
+/* Built-in method references for those with the same name as other `lodash` methods. */
+var nativeKeys = overArg(Object.keys, Object),
+    nativeMax = Math.max;
+
+/** Used to convert symbols to primitives and strings. */
+var symbolProto = Symbol ? Symbol.prototype : undefined,
+    symbolToString = symbolProto ? symbolProto.toString : undefined;
+
 /**
- * The base implementation of `_.keysIn` which doesn't skip the constructor
- * property of prototypes or treat sparse arrays as dense.
+ * Creates an array of the enumerable property names of the array-like `value`.
+ *
+ * @private
+ * @param {*} value The value to query.
+ * @param {boolean} inherited Specify returning inherited property names.
+ * @returns {Array} Returns the array of property names.
+ */
+function arrayLikeKeys(value, inherited) {
+  // Safari 8.1 makes `arguments.callee` enumerable in strict mode.
+  // Safari 9 makes `arguments.length` enumerable in strict mode.
+  var result = (isArray(value) || isArguments(value))
+    ? baseTimes(value.length, String)
+    : [];
+
+  var length = result.length,
+      skipIndexes = !!length;
+
+  for (var key in value) {
+    if ((inherited || hasOwnProperty.call(value, key)) &&
+        !(skipIndexes && (key == 'length' || isIndex(key, length)))) {
+      result.push(key);
+    }
+  }
+  return result;
+}
+
+/**
+ * Used by `_.defaults` to customize its `_.assignIn` use.
+ *
+ * @private
+ * @param {*} objValue The destination value.
+ * @param {*} srcValue The source value.
+ * @param {string} key The key of the property to assign.
+ * @param {Object} object The parent object of `objValue`.
+ * @returns {*} Returns the value to assign.
+ */
+function assignInDefaults(objValue, srcValue, key, object) {
+  if (objValue === undefined ||
+      (eq(objValue, objectProto[key]) && !hasOwnProperty.call(object, key))) {
+    return srcValue;
+  }
+  return objValue;
+}
+
+/**
+ * Assigns `value` to `key` of `object` if the existing value is not equivalent
+ * using [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
+ * for equality comparisons.
+ *
+ * @private
+ * @param {Object} object The object to modify.
+ * @param {string} key The key of the property to assign.
+ * @param {*} value The value to assign.
+ */
+function assignValue(object, key, value) {
+  var objValue = object[key];
+  if (!(hasOwnProperty.call(object, key) && eq(objValue, value)) ||
+      (value === undefined && !(key in object))) {
+    object[key] = value;
+  }
+}
+
+/**
+ * The base implementation of `_.keys` which doesn't treat sparse arrays as dense.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @returns {Array} Returns the array of property names.
+ */
+function baseKeys(object) {
+  if (!isPrototype(object)) {
+    return nativeKeys(object);
+  }
+  var result = [];
+  for (var key in Object(object)) {
+    if (hasOwnProperty.call(object, key) && key != 'constructor') {
+      result.push(key);
+    }
+  }
+  return result;
+}
+
+/**
+ * The base implementation of `_.keysIn` which doesn't treat sparse arrays as dense.
  *
  * @private
  * @param {Object} object The object to query.
  * @returns {Array} Returns the array of property names.
  */
 function baseKeysIn(object) {
-  object = object == null ? object : Object(object);
+  if (!isObject(object)) {
+    return nativeKeysIn(object);
+  }
+  var isProto = isPrototype(object),
+      result = [];
 
-  var result = [];
   for (var key in object) {
-    result.push(key);
+    if (!(key == 'constructor' && (isProto || !hasOwnProperty.call(object, key)))) {
+      result.push(key);
+    }
   }
   return result;
 }
 
-// Fallback for IE < 9 with es6-shim.
-if (enumerate && !propertyIsEnumerable.call({ 'valueOf': 1 }, 'valueOf')) {
-  baseKeysIn = function(object) {
-    return iteratorToArray(enumerate(object));
+/**
+ * The base implementation of `_.rest` which doesn't validate or coerce arguments.
+ *
+ * @private
+ * @param {Function} func The function to apply a rest parameter to.
+ * @param {number} [start=func.length-1] The start position of the rest parameter.
+ * @returns {Function} Returns the new function.
+ */
+function baseRest(func, start) {
+  start = nativeMax(start === undefined ? (func.length - 1) : start, 0);
+  return function() {
+    var args = arguments,
+        index = -1,
+        length = nativeMax(args.length - start, 0),
+        array = Array(length);
+
+    while (++index < length) {
+      array[index] = args[start + index];
+    }
+    index = -1;
+    var otherArgs = Array(start + 1);
+    while (++index < start) {
+      otherArgs[index] = args[index];
+    }
+    otherArgs[start] = array;
+    return apply(func, this, otherArgs);
   };
 }
 
 /**
- * The base implementation of `_.property` without support for deep paths.
+ * The base implementation of `_.toString` which doesn't convert nullish
+ * values to empty strings.
  *
  * @private
- * @param {string} key The key of the property to get.
- * @returns {Function} Returns the new accessor function.
+ * @param {*} value The value to process.
+ * @returns {string} Returns the string.
  */
-function baseProperty(key) {
-  return function(object) {
-    return object == null ? undefined : object[key];
-  };
-}
-
-/**
- * Gets the "length" property value of `object`.
- *
- * **Note:** This function is used to avoid a
- * [JIT bug](https://bugs.webkit.org/show_bug.cgi?id=142792) that affects
- * Safari on at least iOS 8.1-8.3 ARM64.
- *
- * @private
- * @param {Object} object The object to query.
- * @returns {*} Returns the "length" value.
- */
-var getLength = baseProperty('length');
-
-/**
- * Creates an array of index keys for `object` values of arrays,
- * `arguments` objects, and strings, otherwise `null` is returned.
- *
- * @private
- * @param {Object} object The object to query.
- * @returns {Array|null} Returns index keys, else `null`.
- */
-function indexKeys(object) {
-  var length = object ? object.length : undefined;
-  if (isLength(length) &&
-      (isArray(object) || isString(object) || isArguments(object))) {
-    return baseTimes(length, String);
+function baseToString(value) {
+  // Exit early for strings to avoid a performance hit in some environments.
+  if (typeof value == 'string') {
+    return value;
   }
-  return null;
+  if (isSymbol(value)) {
+    return symbolToString ? symbolToString.call(value) : '';
+  }
+  var result = (value + '');
+  return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result;
+}
+
+/**
+ * Copies properties of `source` to `object`.
+ *
+ * @private
+ * @param {Object} source The object to copy properties from.
+ * @param {Array} props The property identifiers to copy.
+ * @param {Object} [object={}] The object to copy properties to.
+ * @param {Function} [customizer] The function to customize copied values.
+ * @returns {Object} Returns `object`.
+ */
+function copyObject(source, props, object, customizer) {
+  object || (object = {});
+
+  var index = -1,
+      length = props.length;
+
+  while (++index < length) {
+    var key = props[index];
+
+    var newValue = customizer
+      ? customizer(object[key], source[key], key, object, source)
+      : undefined;
+
+    assignValue(object, key, newValue === undefined ? source[key] : newValue);
+  }
+  return object;
+}
+
+/**
+ * Creates a function like `_.assign`.
+ *
+ * @private
+ * @param {Function} assigner The function to assign values.
+ * @returns {Function} Returns the new assigner function.
+ */
+function createAssigner(assigner) {
+  return baseRest(function(object, sources) {
+    var index = -1,
+        length = sources.length,
+        customizer = length > 1 ? sources[length - 1] : undefined,
+        guard = length > 2 ? sources[2] : undefined;
+
+    customizer = (assigner.length > 3 && typeof customizer == 'function')
+      ? (length--, customizer)
+      : undefined;
+
+    if (guard && isIterateeCall(sources[0], sources[1], guard)) {
+      customizer = length < 3 ? undefined : customizer;
+      length = 1;
+    }
+    object = Object(object);
+    while (++index < length) {
+      var source = sources[index];
+      if (source) {
+        assigner(object, source, index, customizer);
+      }
+    }
+    return object;
+  });
 }
 
 /**
@@ -3445,6 +2947,30 @@ function isIndex(value, length) {
 }
 
 /**
+ * Checks if the given arguments are from an iteratee call.
+ *
+ * @private
+ * @param {*} value The potential iteratee value argument.
+ * @param {*} index The potential iteratee index or key argument.
+ * @param {*} object The potential iteratee object argument.
+ * @returns {boolean} Returns `true` if the arguments are from an iteratee call,
+ *  else `false`.
+ */
+function isIterateeCall(value, index, object) {
+  if (!isObject(object)) {
+    return false;
+  }
+  var type = typeof index;
+  if (type == 'number'
+        ? (isArrayLike(object) && isIndex(index, object.length))
+        : (type == 'string' && index in object)
+      ) {
+    return eq(object[index], value);
+  }
+  return false;
+}
+
+/**
  * Checks if `value` is likely a prototype object.
  *
  * @private
@@ -3459,6 +2985,61 @@ function isPrototype(value) {
 }
 
 /**
+ * This function is like
+ * [`Object.keys`](http://ecma-international.org/ecma-262/7.0/#sec-object.keys)
+ * except that it includes inherited enumerable properties.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @returns {Array} Returns the array of property names.
+ */
+function nativeKeysIn(object) {
+  var result = [];
+  if (object != null) {
+    for (var key in Object(object)) {
+      result.push(key);
+    }
+  }
+  return result;
+}
+
+/**
+ * Performs a
+ * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
+ * comparison between two values to determine if they are equivalent.
+ *
+ * @static
+ * @memberOf _
+ * @since 4.0.0
+ * @category Lang
+ * @param {*} value The value to compare.
+ * @param {*} other The other value to compare.
+ * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
+ * @example
+ *
+ * var object = { 'a': 1 };
+ * var other = { 'a': 1 };
+ *
+ * _.eq(object, object);
+ * // => true
+ *
+ * _.eq(object, other);
+ * // => false
+ *
+ * _.eq('a', 'a');
+ * // => true
+ *
+ * _.eq('a', Object('a'));
+ * // => false
+ *
+ * _.eq(NaN, NaN);
+ * // => true
+ */
+function eq(value, other) {
+  return value === other || (value !== value && other !== other);
+}
+
+/**
  * Checks if `value` is likely an `arguments` object.
  *
  * @static
@@ -3466,7 +3047,7 @@ function isPrototype(value) {
  * @since 0.1.0
  * @category Lang
  * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
+ * @returns {boolean} Returns `true` if `value` is an `arguments` object,
  *  else `false`.
  * @example
  *
@@ -3477,7 +3058,7 @@ function isPrototype(value) {
  * // => false
  */
 function isArguments(value) {
-  // Safari 8.1 incorrectly makes `arguments.callee` enumerable in strict mode.
+  // Safari 8.1 makes `arguments.callee` enumerable in strict mode.
   return isArrayLikeObject(value) && hasOwnProperty.call(value, 'callee') &&
     (!propertyIsEnumerable.call(value, 'callee') || objectToString.call(value) == argsTag);
 }
@@ -3488,11 +3069,9 @@ function isArguments(value) {
  * @static
  * @memberOf _
  * @since 0.1.0
- * @type {Function}
  * @category Lang
  * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
+ * @returns {boolean} Returns `true` if `value` is an array, else `false`.
  * @example
  *
  * _.isArray([1, 2, 3]);
@@ -3535,7 +3114,7 @@ var isArray = Array.isArray;
  * // => false
  */
 function isArrayLike(value) {
-  return value != null && isLength(getLength(value)) && !isFunction(value);
+  return value != null && isLength(value.length) && !isFunction(value);
 }
 
 /**
@@ -3568,6 +3147,32 @@ function isArrayLikeObject(value) {
 }
 
 /**
+ * Checks if `value` is an `Error`, `EvalError`, `RangeError`, `ReferenceError`,
+ * `SyntaxError`, `TypeError`, or `URIError` object.
+ *
+ * @static
+ * @memberOf _
+ * @since 3.0.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is an error object, else `false`.
+ * @example
+ *
+ * _.isError(new Error);
+ * // => true
+ *
+ * _.isError(Error);
+ * // => false
+ */
+function isError(value) {
+  if (!isObjectLike(value)) {
+    return false;
+  }
+  return (objectToString.call(value) == errorTag) ||
+    (typeof value.message == 'string' && typeof value.name == 'string');
+}
+
+/**
  * Checks if `value` is classified as a `Function` object.
  *
  * @static
@@ -3575,8 +3180,7 @@ function isArrayLikeObject(value) {
  * @since 0.1.0
  * @category Lang
  * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
+ * @returns {boolean} Returns `true` if `value` is a function, else `false`.
  * @example
  *
  * _.isFunction(_);
@@ -3587,8 +3191,7 @@ function isArrayLikeObject(value) {
  */
 function isFunction(value) {
   // The use of `Object#toString` avoids issues with the `typeof` operator
-  // in Safari 8 which returns 'object' for typed array and weak map constructors,
-  // and PhantomJS 1.9 which returns 'function' for `NodeList` instances.
+  // in Safari 8-9 which returns 'object' for typed array and other constructors.
   var tag = isObject(value) ? objectToString.call(value) : '';
   return tag == funcTag || tag == genTag;
 }
@@ -3596,16 +3199,15 @@ function isFunction(value) {
 /**
  * Checks if `value` is a valid array-like length.
  *
- * **Note:** This function is loosely based on
- * [`ToLength`](http://ecma-international.org/ecma-262/6.0/#sec-tolength).
+ * **Note:** This method is loosely based on
+ * [`ToLength`](http://ecma-international.org/ecma-262/7.0/#sec-tolength).
  *
  * @static
  * @memberOf _
  * @since 4.0.0
  * @category Lang
  * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a valid length,
- *  else `false`.
+ * @returns {boolean} Returns `true` if `value` is a valid length, else `false`.
  * @example
  *
  * _.isLength(3);
@@ -3627,286 +3229,7 @@ function isLength(value) {
 
 /**
  * Checks if `value` is the
- * [language type](http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-language-types)
- * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is an object, else `false`.
- * @example
- *
- * _.isObject({});
- * // => true
- *
- * _.isObject([1, 2, 3]);
- * // => true
- *
- * _.isObject(_.noop);
- * // => true
- *
- * _.isObject(null);
- * // => false
- */
-function isObject(value) {
-  var type = typeof value;
-  return !!value && (type == 'object' || type == 'function');
-}
-
-/**
- * Checks if `value` is object-like. A value is object-like if it's not `null`
- * and has a `typeof` result of "object".
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
- * @example
- *
- * _.isObjectLike({});
- * // => true
- *
- * _.isObjectLike([1, 2, 3]);
- * // => true
- *
- * _.isObjectLike(_.noop);
- * // => false
- *
- * _.isObjectLike(null);
- * // => false
- */
-function isObjectLike(value) {
-  return !!value && typeof value == 'object';
-}
-
-/**
- * Checks if `value` is classified as a `String` primitive or object.
- *
- * @static
- * @since 0.1.0
- * @memberOf _
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
- * @example
- *
- * _.isString('abc');
- * // => true
- *
- * _.isString(1);
- * // => false
- */
-function isString(value) {
-  return typeof value == 'string' ||
-    (!isArray(value) && isObjectLike(value) && objectToString.call(value) == stringTag);
-}
-
-/**
- * Creates an array of the own and inherited enumerable property names of `object`.
- *
- * **Note:** Non-object values are coerced to objects.
- *
- * @static
- * @memberOf _
- * @since 3.0.0
- * @category Object
- * @param {Object} object The object to query.
- * @returns {Array} Returns the array of property names.
- * @example
- *
- * function Foo() {
- *   this.a = 1;
- *   this.b = 2;
- * }
- *
- * Foo.prototype.c = 3;
- *
- * _.keysIn(new Foo);
- * // => ['a', 'b', 'c'] (iteration order is not guaranteed)
- */
-function keysIn(object) {
-  var index = -1,
-      isProto = isPrototype(object),
-      props = baseKeysIn(object),
-      propsLength = props.length,
-      indexes = indexKeys(object),
-      skipIndexes = !!indexes,
-      result = indexes || [],
-      length = result.length;
-
-  while (++index < propsLength) {
-    var key = props[index];
-    if (!(skipIndexes && (key == 'length' || isIndex(key, length))) &&
-        !(key == 'constructor' && (isProto || !hasOwnProperty.call(object, key)))) {
-      result.push(key);
-    }
-  }
-  return result;
-}
-
-module.exports = keysIn;
-
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],12:[function(require,module,exports){
-/**
- * lodash (Custom Build) <https://lodash.com/>
- * Build: `lodash modularize exports="npm" -o ./`
- * Copyright jQuery Foundation and other contributors <https://jquery.org/>
- * Released under MIT license <https://lodash.com/license>
- * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
- * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
- */
-
-/** Used as the `TypeError` message for "Functions" methods. */
-var FUNC_ERROR_TEXT = 'Expected a function';
-
-/** Used as references for various `Number` constants. */
-var INFINITY = 1 / 0,
-    MAX_INTEGER = 1.7976931348623157e+308,
-    NAN = 0 / 0;
-
-/** `Object#toString` result references. */
-var funcTag = '[object Function]',
-    genTag = '[object GeneratorFunction]',
-    symbolTag = '[object Symbol]';
-
-/** Used to match leading and trailing whitespace. */
-var reTrim = /^\s+|\s+$/g;
-
-/** Used to detect bad signed hexadecimal string values. */
-var reIsBadHex = /^[-+]0x[0-9a-f]+$/i;
-
-/** Used to detect binary string values. */
-var reIsBinary = /^0b[01]+$/i;
-
-/** Used to detect octal string values. */
-var reIsOctal = /^0o[0-7]+$/i;
-
-/** Built-in method references without a dependency on `root`. */
-var freeParseInt = parseInt;
-
-/**
- * A faster alternative to `Function#apply`, this function invokes `func`
- * with the `this` binding of `thisArg` and the arguments of `args`.
- *
- * @private
- * @param {Function} func The function to invoke.
- * @param {*} thisArg The `this` binding of `func`.
- * @param {Array} args The arguments to invoke `func` with.
- * @returns {*} Returns the result of `func`.
- */
-function apply(func, thisArg, args) {
-  var length = args.length;
-  switch (length) {
-    case 0: return func.call(thisArg);
-    case 1: return func.call(thisArg, args[0]);
-    case 2: return func.call(thisArg, args[0], args[1]);
-    case 3: return func.call(thisArg, args[0], args[1], args[2]);
-  }
-  return func.apply(thisArg, args);
-}
-
-/** Used for built-in method references. */
-var objectProto = Object.prototype;
-
-/**
- * Used to resolve the
- * [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
- * of values.
- */
-var objectToString = objectProto.toString;
-
-/* Built-in method references for those with the same name as other `lodash` methods. */
-var nativeMax = Math.max;
-
-/**
- * Creates a function that invokes `func` with the `this` binding of the
- * created function and arguments from `start` and beyond provided as
- * an array.
- *
- * **Note:** This method is based on the
- * [rest parameter](https://mdn.io/rest_parameters).
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Function
- * @param {Function} func The function to apply a rest parameter to.
- * @param {number} [start=func.length-1] The start position of the rest parameter.
- * @returns {Function} Returns the new function.
- * @example
- *
- * var say = _.rest(function(what, names) {
- *   return what + ' ' + _.initial(names).join(', ') +
- *     (_.size(names) > 1 ? ', & ' : '') + _.last(names);
- * });
- *
- * say('hello', 'fred', 'barney', 'pebbles');
- * // => 'hello fred, barney, & pebbles'
- */
-function rest(func, start) {
-  if (typeof func != 'function') {
-    throw new TypeError(FUNC_ERROR_TEXT);
-  }
-  start = nativeMax(start === undefined ? (func.length - 1) : toInteger(start), 0);
-  return function() {
-    var args = arguments,
-        index = -1,
-        length = nativeMax(args.length - start, 0),
-        array = Array(length);
-
-    while (++index < length) {
-      array[index] = args[start + index];
-    }
-    switch (start) {
-      case 0: return func.call(this, array);
-      case 1: return func.call(this, args[0], array);
-      case 2: return func.call(this, args[0], args[1], array);
-    }
-    var otherArgs = Array(start + 1);
-    index = -1;
-    while (++index < start) {
-      otherArgs[index] = args[index];
-    }
-    otherArgs[start] = array;
-    return apply(func, this, otherArgs);
-  };
-}
-
-/**
- * Checks if `value` is classified as a `Function` object.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
- * @example
- *
- * _.isFunction(_);
- * // => true
- *
- * _.isFunction(/abc/);
- * // => false
- */
-function isFunction(value) {
-  // The use of `Object#toString` avoids issues with the `typeof` operator
-  // in Safari 8 which returns 'object' for typed array and weak map constructors,
-  // and PhantomJS 1.9 which returns 'function' for `NodeList` instances.
-  var tag = isObject(value) ? objectToString.call(value) : '';
-  return tag == funcTag || tag == genTag;
-}
-
-/**
- * Checks if `value` is the
- * [language type](http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-language-types)
+ * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
  * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
  *
  * @static
@@ -3970,8 +3293,7 @@ function isObjectLike(value) {
  * @since 4.0.0
  * @category Lang
  * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
+ * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
  * @example
  *
  * _.isSymbol(Symbol.iterator);
@@ -3986,543 +3308,120 @@ function isSymbol(value) {
 }
 
 /**
- * Converts `value` to a finite number.
- *
- * @static
- * @memberOf _
- * @since 4.12.0
- * @category Lang
- * @param {*} value The value to convert.
- * @returns {number} Returns the converted number.
- * @example
- *
- * _.toFinite(3.2);
- * // => 3.2
- *
- * _.toFinite(Number.MIN_VALUE);
- * // => 5e-324
- *
- * _.toFinite(Infinity);
- * // => 1.7976931348623157e+308
- *
- * _.toFinite('3.2');
- * // => 3.2
- */
-function toFinite(value) {
-  if (!value) {
-    return value === 0 ? value : 0;
-  }
-  value = toNumber(value);
-  if (value === INFINITY || value === -INFINITY) {
-    var sign = (value < 0 ? -1 : 1);
-    return sign * MAX_INTEGER;
-  }
-  return value === value ? value : 0;
-}
-
-/**
- * Converts `value` to an integer.
- *
- * **Note:** This function is loosely based on
- * [`ToInteger`](http://www.ecma-international.org/ecma-262/6.0/#sec-tointeger).
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to convert.
- * @returns {number} Returns the converted integer.
- * @example
- *
- * _.toInteger(3.2);
- * // => 3
- *
- * _.toInteger(Number.MIN_VALUE);
- * // => 0
- *
- * _.toInteger(Infinity);
- * // => 1.7976931348623157e+308
- *
- * _.toInteger('3.2');
- * // => 3
- */
-function toInteger(value) {
-  var result = toFinite(value),
-      remainder = result % 1;
-
-  return result === result ? (remainder ? result - remainder : result) : 0;
-}
-
-/**
- * Converts `value` to a number.
+ * Converts `value` to a string. An empty string is returned for `null`
+ * and `undefined` values. The sign of `-0` is preserved.
  *
  * @static
  * @memberOf _
  * @since 4.0.0
  * @category Lang
  * @param {*} value The value to process.
- * @returns {number} Returns the number.
+ * @returns {string} Returns the string.
  * @example
  *
- * _.toNumber(3.2);
- * // => 3.2
+ * _.toString(null);
+ * // => ''
  *
- * _.toNumber(Number.MIN_VALUE);
- * // => 5e-324
+ * _.toString(-0);
+ * // => '-0'
  *
- * _.toNumber(Infinity);
- * // => Infinity
- *
- * _.toNumber('3.2');
- * // => 3.2
+ * _.toString([1, 2, 3]);
+ * // => '1,2,3'
  */
-function toNumber(value) {
-  if (typeof value == 'number') {
-    return value;
-  }
-  if (isSymbol(value)) {
-    return NAN;
-  }
-  if (isObject(value)) {
-    var other = isFunction(value.valueOf) ? value.valueOf() : value;
-    value = isObject(other) ? (other + '') : other;
-  }
-  if (typeof value != 'string') {
-    return value === 0 ? value : +value;
-  }
-  value = value.replace(reTrim, '');
-  var isBinary = reIsBinary.test(value);
-  return (isBinary || reIsOctal.test(value))
-    ? freeParseInt(value.slice(2), isBinary ? 2 : 8)
-    : (reIsBadHex.test(value) ? NAN : +value);
-}
-
-module.exports = rest;
-
-},{}],13:[function(require,module,exports){
-/**
- * lodash (Custom Build) <https://lodash.com/>
- * Build: `lodash modularize exports="npm" -o ./`
- * Copyright jQuery Foundation and other contributors <https://jquery.org/>
- * Released under MIT license <https://lodash.com/license>
- * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
- * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
- */
-var assignInWith = require('lodash.assigninwith'),
-    keys = require('lodash.keys'),
-    reInterpolate = require('lodash._reinterpolate'),
-    rest = require('lodash.rest'),
-    templateSettings = require('lodash.templatesettings'),
-    toString = require('lodash.tostring');
-
-/** Used as references for various `Number` constants. */
-var MAX_SAFE_INTEGER = 9007199254740991;
-
-/** `Object#toString` result references. */
-var errorTag = '[object Error]',
-    funcTag = '[object Function]',
-    genTag = '[object GeneratorFunction]';
-
-/** Used to match empty string literals in compiled template source. */
-var reEmptyStringLeading = /\b__p \+= '';/g,
-    reEmptyStringMiddle = /\b(__p \+=) '' \+/g,
-    reEmptyStringTrailing = /(__e\(.*?\)|\b__t\)) \+\n'';/g;
-
-/**
- * Used to match
- * [ES template delimiters](http://ecma-international.org/ecma-262/6.0/#sec-template-literal-lexical-components).
- */
-var reEsTemplate = /\$\{([^\\}]*(?:\\.[^\\}]*)*)\}/g;
-
-/** Used to detect unsigned integer values. */
-var reIsUint = /^(?:0|[1-9]\d*)$/;
-
-/** Used to ensure capturing order of template delimiters. */
-var reNoMatch = /($^)/;
-
-/** Used to match unescaped characters in compiled string literals. */
-var reUnescapedString = /['\n\r\u2028\u2029\\]/g;
-
-/** Used to escape characters for inclusion in compiled string literals. */
-var stringEscapes = {
-  '\\': '\\',
-  "'": "'",
-  '\n': 'n',
-  '\r': 'r',
-  '\u2028': 'u2028',
-  '\u2029': 'u2029'
-};
-
-/**
- * A faster alternative to `Function#apply`, this function invokes `func`
- * with the `this` binding of `thisArg` and the arguments of `args`.
- *
- * @private
- * @param {Function} func The function to invoke.
- * @param {*} thisArg The `this` binding of `func`.
- * @param {Array} args The arguments to invoke `func` with.
- * @returns {*} Returns the result of `func`.
- */
-function apply(func, thisArg, args) {
-  var length = args.length;
-  switch (length) {
-    case 0: return func.call(thisArg);
-    case 1: return func.call(thisArg, args[0]);
-    case 2: return func.call(thisArg, args[0], args[1]);
-    case 3: return func.call(thisArg, args[0], args[1], args[2]);
-  }
-  return func.apply(thisArg, args);
+function toString(value) {
+  return value == null ? '' : baseToString(value);
 }
 
 /**
- * A specialized version of `_.map` for arrays without support for iteratee
- * shorthands.
+ * This method is like `_.assignIn` except that it accepts `customizer`
+ * which is invoked to produce the assigned values. If `customizer` returns
+ * `undefined`, assignment is handled by the method instead. The `customizer`
+ * is invoked with five arguments: (objValue, srcValue, key, object, source).
  *
- * @private
- * @param {Array} array The array to iterate over.
- * @param {Function} iteratee The function invoked per iteration.
- * @returns {Array} Returns the new mapped array.
- */
-function arrayMap(array, iteratee) {
-  var index = -1,
-      length = array.length,
-      result = Array(length);
-
-  while (++index < length) {
-    result[index] = iteratee(array[index], index, array);
-  }
-  return result;
-}
-
-/**
- * The base implementation of `_.values` and `_.valuesIn` which creates an
- * array of `object` property values corresponding to the property names
- * of `props`.
- *
- * @private
- * @param {Object} object The object to query.
- * @param {Array} props The property names to get values for.
- * @returns {Object} Returns the array of property values.
- */
-function baseValues(object, props) {
-  return arrayMap(props, function(key) {
-    return object[key];
-  });
-}
-
-/**
- * Used by `_.template` to escape characters for inclusion in compiled string literals.
- *
- * @private
- * @param {string} chr The matched character to escape.
- * @returns {string} Returns the escaped character.
- */
-function escapeStringChar(chr) {
-  return '\\' + stringEscapes[chr];
-}
-
-/** Used for built-in method references. */
-var objectProto = Object.prototype;
-
-/** Used to check objects for own properties. */
-var hasOwnProperty = objectProto.hasOwnProperty;
-
-/**
- * Used to resolve the
- * [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
- * of values.
- */
-var objectToString = objectProto.toString;
-
-/**
- * Used by `_.defaults` to customize its `_.assignIn` use.
- *
- * @private
- * @param {*} objValue The destination value.
- * @param {*} srcValue The source value.
- * @param {string} key The key of the property to assign.
- * @param {Object} object The parent object of `objValue`.
- * @returns {*} Returns the value to assign.
- */
-function assignInDefaults(objValue, srcValue, key, object) {
-  if (objValue === undefined ||
-      (eq(objValue, objectProto[key]) && !hasOwnProperty.call(object, key))) {
-    return srcValue;
-  }
-  return objValue;
-}
-
-/**
- * The base implementation of `_.property` without support for deep paths.
- *
- * @private
- * @param {string} key The key of the property to get.
- * @returns {Function} Returns the new accessor function.
- */
-function baseProperty(key) {
-  return function(object) {
-    return object == null ? undefined : object[key];
-  };
-}
-
-/**
- * Gets the "length" property value of `object`.
- *
- * **Note:** This function is used to avoid a
- * [JIT bug](https://bugs.webkit.org/show_bug.cgi?id=142792) that affects
- * Safari on at least iOS 8.1-8.3 ARM64.
- *
- * @private
- * @param {Object} object The object to query.
- * @returns {*} Returns the "length" value.
- */
-var getLength = baseProperty('length');
-
-/**
- * Checks if `value` is a valid array-like index.
- *
- * @private
- * @param {*} value The value to check.
- * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
- * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
- */
-function isIndex(value, length) {
-  length = length == null ? MAX_SAFE_INTEGER : length;
-  return !!length &&
-    (typeof value == 'number' || reIsUint.test(value)) &&
-    (value > -1 && value % 1 == 0 && value < length);
-}
-
-/**
- * Checks if the given arguments are from an iteratee call.
- *
- * @private
- * @param {*} value The potential iteratee value argument.
- * @param {*} index The potential iteratee index or key argument.
- * @param {*} object The potential iteratee object argument.
- * @returns {boolean} Returns `true` if the arguments are from an iteratee call,
- *  else `false`.
- */
-function isIterateeCall(value, index, object) {
-  if (!isObject(object)) {
-    return false;
-  }
-  var type = typeof index;
-  if (type == 'number'
-        ? (isArrayLike(object) && isIndex(index, object.length))
-        : (type == 'string' && index in object)
-      ) {
-    return eq(object[index], value);
-  }
-  return false;
-}
-
-/**
- * Performs a
- * [`SameValueZero`](http://ecma-international.org/ecma-262/6.0/#sec-samevaluezero)
- * comparison between two values to determine if they are equivalent.
+ * **Note:** This method mutates `object`.
  *
  * @static
  * @memberOf _
  * @since 4.0.0
- * @category Lang
- * @param {*} value The value to compare.
- * @param {*} other The other value to compare.
- * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
+ * @alias extendWith
+ * @category Object
+ * @param {Object} object The destination object.
+ * @param {...Object} sources The source objects.
+ * @param {Function} [customizer] The function to customize assigned values.
+ * @returns {Object} Returns `object`.
+ * @see _.assignWith
  * @example
  *
- * var object = { 'user': 'fred' };
- * var other = { 'user': 'fred' };
+ * function customizer(objValue, srcValue) {
+ *   return _.isUndefined(objValue) ? srcValue : objValue;
+ * }
  *
- * _.eq(object, object);
- * // => true
+ * var defaults = _.partialRight(_.assignInWith, customizer);
  *
- * _.eq(object, other);
- * // => false
- *
- * _.eq('a', 'a');
- * // => true
- *
- * _.eq('a', Object('a'));
- * // => false
- *
- * _.eq(NaN, NaN);
- * // => true
+ * defaults({ 'a': 1 }, { 'b': 2 }, { 'a': 3 });
+ * // => { 'a': 1, 'b': 2 }
  */
-function eq(value, other) {
-  return value === other || (value !== value && other !== other);
-}
+var assignInWith = createAssigner(function(object, source, srcIndex, customizer) {
+  copyObject(source, keysIn(source), object, customizer);
+});
 
 /**
- * Checks if `value` is array-like. A value is considered array-like if it's
- * not a function and has a `value.length` that's an integer greater than or
- * equal to `0` and less than or equal to `Number.MAX_SAFE_INTEGER`.
+ * Creates an array of the own enumerable property names of `object`.
+ *
+ * **Note:** Non-object values are coerced to objects. See the
+ * [ES spec](http://ecma-international.org/ecma-262/7.0/#sec-object.keys)
+ * for more details.
  *
  * @static
+ * @since 0.1.0
  * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is array-like, else `false`.
+ * @category Object
+ * @param {Object} object The object to query.
+ * @returns {Array} Returns the array of property names.
  * @example
  *
- * _.isArrayLike([1, 2, 3]);
- * // => true
+ * function Foo() {
+ *   this.a = 1;
+ *   this.b = 2;
+ * }
  *
- * _.isArrayLike(document.body.children);
- * // => true
+ * Foo.prototype.c = 3;
  *
- * _.isArrayLike('abc');
- * // => true
+ * _.keys(new Foo);
+ * // => ['a', 'b'] (iteration order is not guaranteed)
  *
- * _.isArrayLike(_.noop);
- * // => false
+ * _.keys('hi');
+ * // => ['0', '1']
  */
-function isArrayLike(value) {
-  return value != null && isLength(getLength(value)) && !isFunction(value);
+function keys(object) {
+  return isArrayLike(object) ? arrayLikeKeys(object) : baseKeys(object);
 }
 
 /**
- * Checks if `value` is an `Error`, `EvalError`, `RangeError`, `ReferenceError`,
- * `SyntaxError`, `TypeError`, or `URIError` object.
+ * Creates an array of the own and inherited enumerable property names of `object`.
+ *
+ * **Note:** Non-object values are coerced to objects.
  *
  * @static
  * @memberOf _
  * @since 3.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is an error object,
- *  else `false`.
+ * @category Object
+ * @param {Object} object The object to query.
+ * @returns {Array} Returns the array of property names.
  * @example
  *
- * _.isError(new Error);
- * // => true
+ * function Foo() {
+ *   this.a = 1;
+ *   this.b = 2;
+ * }
  *
- * _.isError(Error);
- * // => false
+ * Foo.prototype.c = 3;
+ *
+ * _.keysIn(new Foo);
+ * // => ['a', 'b', 'c'] (iteration order is not guaranteed)
  */
-function isError(value) {
-  if (!isObjectLike(value)) {
-    return false;
-  }
-  return (objectToString.call(value) == errorTag) ||
-    (typeof value.message == 'string' && typeof value.name == 'string');
-}
-
-/**
- * Checks if `value` is classified as a `Function` object.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
- * @example
- *
- * _.isFunction(_);
- * // => true
- *
- * _.isFunction(/abc/);
- * // => false
- */
-function isFunction(value) {
-  // The use of `Object#toString` avoids issues with the `typeof` operator
-  // in Safari 8 which returns 'object' for typed array and weak map constructors,
-  // and PhantomJS 1.9 which returns 'function' for `NodeList` instances.
-  var tag = isObject(value) ? objectToString.call(value) : '';
-  return tag == funcTag || tag == genTag;
-}
-
-/**
- * Checks if `value` is a valid array-like length.
- *
- * **Note:** This function is loosely based on
- * [`ToLength`](http://ecma-international.org/ecma-262/6.0/#sec-tolength).
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a valid length,
- *  else `false`.
- * @example
- *
- * _.isLength(3);
- * // => true
- *
- * _.isLength(Number.MIN_VALUE);
- * // => false
- *
- * _.isLength(Infinity);
- * // => false
- *
- * _.isLength('3');
- * // => false
- */
-function isLength(value) {
-  return typeof value == 'number' &&
-    value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER;
-}
-
-/**
- * Checks if `value` is the
- * [language type](http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-language-types)
- * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is an object, else `false`.
- * @example
- *
- * _.isObject({});
- * // => true
- *
- * _.isObject([1, 2, 3]);
- * // => true
- *
- * _.isObject(_.noop);
- * // => true
- *
- * _.isObject(null);
- * // => false
- */
-function isObject(value) {
-  var type = typeof value;
-  return !!value && (type == 'object' || type == 'function');
-}
-
-/**
- * Checks if `value` is object-like. A value is object-like if it's not `null`
- * and has a `typeof` result of "object".
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
- * @example
- *
- * _.isObjectLike({});
- * // => true
- *
- * _.isObjectLike([1, 2, 3]);
- * // => true
- *
- * _.isObjectLike(_.noop);
- * // => false
- *
- * _.isObjectLike(null);
- * // => false
- */
-function isObjectLike(value) {
-  return !!value && typeof value == 'object';
+function keysIn(object) {
+  return isArrayLike(object) ? arrayLikeKeys(object, true) : baseKeysIn(object);
 }
 
 /**
@@ -4754,7 +3653,7 @@ function template(string, options, guard) {
  *   elements = [];
  * }
  */
-var attempt = rest(function(func, args) {
+var attempt = baseRest(function(func, args) {
   try {
     return apply(func, undefined, args);
   } catch (e) {
@@ -4764,21 +3663,90 @@ var attempt = rest(function(func, args) {
 
 module.exports = template;
 
-},{"lodash._reinterpolate":4,"lodash.assigninwith":6,"lodash.keys":10,"lodash.rest":12,"lodash.templatesettings":14,"lodash.tostring":15}],14:[function(require,module,exports){
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{"lodash._reinterpolate":4,"lodash.templatesettings":8}],8:[function(require,module,exports){
+(function (global){
 /**
- * lodash 4.0.1 (Custom Build) <https://lodash.com/>
+ * lodash (Custom Build) <https://lodash.com/>
  * Build: `lodash modularize exports="npm" -o ./`
- * Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
+ * Copyright jQuery Foundation and other contributors <https://jquery.org/>
+ * Released under MIT license <https://lodash.com/license>
  * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
- * Copyright 2009-2016 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
- * Available under MIT license <https://lodash.com/license>
+ * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
  */
-var escape = require('lodash.escape'),
-    reInterpolate = require('lodash._reinterpolate');
+var reInterpolate = require('lodash._reinterpolate');
+
+/** Used as references for various `Number` constants. */
+var INFINITY = 1 / 0;
+
+/** `Object#toString` result references. */
+var symbolTag = '[object Symbol]';
+
+/** Used to match HTML entities and HTML characters. */
+var reUnescapedHtml = /[&<>"'`]/g,
+    reHasUnescapedHtml = RegExp(reUnescapedHtml.source);
 
 /** Used to match template delimiters. */
 var reEscape = /<%-([\s\S]+?)%>/g,
     reEvaluate = /<%([\s\S]+?)%>/g;
+
+/** Used to map characters to HTML entities. */
+var htmlEscapes = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+  '`': '&#96;'
+};
+
+/** Detect free variable `global` from Node.js. */
+var freeGlobal = typeof global == 'object' && global && global.Object === Object && global;
+
+/** Detect free variable `self`. */
+var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
+
+/** Used as a reference to the global object. */
+var root = freeGlobal || freeSelf || Function('return this')();
+
+/**
+ * The base implementation of `_.propertyOf` without support for deep paths.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @returns {Function} Returns the new accessor function.
+ */
+function basePropertyOf(object) {
+  return function(key) {
+    return object == null ? undefined : object[key];
+  };
+}
+
+/**
+ * Used by `_.escape` to convert characters to HTML entities.
+ *
+ * @private
+ * @param {string} chr The matched character to escape.
+ * @returns {string} Returns the escaped character.
+ */
+var escapeHtmlChar = basePropertyOf(htmlEscapes);
+
+/** Used for built-in method references. */
+var objectProto = Object.prototype;
+
+/**
+ * Used to resolve the
+ * [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+ * of values.
+ */
+var objectToString = objectProto.toString;
+
+/** Built-in value references. */
+var Symbol = root.Symbol;
+
+/** Used to convert symbols to primitives and strings. */
+var symbolProto = Symbol ? Symbol.prototype : undefined,
+    symbolToString = symbolProto ? symbolProto.toString : undefined;
 
 /**
  * By default, the template delimiters used by lodash are like those in
@@ -4841,91 +3809,6 @@ var templateSettings = {
   }
 };
 
-module.exports = templateSettings;
-
-},{"lodash._reinterpolate":4,"lodash.escape":8}],15:[function(require,module,exports){
-(function (global){
-/**
- * lodash (Custom Build) <https://lodash.com/>
- * Build: `lodash modularize exports="npm" -o ./`
- * Copyright jQuery Foundation and other contributors <https://jquery.org/>
- * Released under MIT license <https://lodash.com/license>
- * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
- * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
- */
-
-/** Used as references for various `Number` constants. */
-var INFINITY = 1 / 0;
-
-/** `Object#toString` result references. */
-var symbolTag = '[object Symbol]';
-
-/** Used to determine if values are of the language type `Object`. */
-var objectTypes = {
-  'function': true,
-  'object': true
-};
-
-/** Detect free variable `exports`. */
-var freeExports = (objectTypes[typeof exports] && exports && !exports.nodeType)
-  ? exports
-  : undefined;
-
-/** Detect free variable `module`. */
-var freeModule = (objectTypes[typeof module] && module && !module.nodeType)
-  ? module
-  : undefined;
-
-/** Detect free variable `global` from Node.js. */
-var freeGlobal = checkGlobal(freeExports && freeModule && typeof global == 'object' && global);
-
-/** Detect free variable `self`. */
-var freeSelf = checkGlobal(objectTypes[typeof self] && self);
-
-/** Detect free variable `window`. */
-var freeWindow = checkGlobal(objectTypes[typeof window] && window);
-
-/** Detect `this` as the global object. */
-var thisGlobal = checkGlobal(objectTypes[typeof this] && this);
-
-/**
- * Used as a reference to the global object.
- *
- * The `this` value is used if it's the global object to avoid Greasemonkey's
- * restricted `window` object, otherwise the `window` object is used.
- */
-var root = freeGlobal ||
-  ((freeWindow !== (thisGlobal && thisGlobal.window)) && freeWindow) ||
-    freeSelf || thisGlobal || Function('return this')();
-
-/**
- * Checks if `value` is a global object.
- *
- * @private
- * @param {*} value The value to check.
- * @returns {null|Object} Returns `value` if it's a global object, else `null`.
- */
-function checkGlobal(value) {
-  return (value && value.Object === Object) ? value : null;
-}
-
-/** Used for built-in method references. */
-var objectProto = Object.prototype;
-
-/**
- * Used to resolve the
- * [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
- * of values.
- */
-var objectToString = objectProto.toString;
-
-/** Built-in value references. */
-var Symbol = root.Symbol;
-
-/** Used to convert symbols to primitives and strings. */
-var symbolProto = Symbol ? Symbol.prototype : undefined,
-    symbolToString = symbolProto ? symbolProto.toString : undefined;
-
 /**
  * The base implementation of `_.toString` which doesn't convert nullish
  * values to empty strings.
@@ -4982,8 +3865,7 @@ function isObjectLike(value) {
  * @since 4.0.0
  * @category Lang
  * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is correctly classified,
- *  else `false`.
+ * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
  * @example
  *
  * _.isSymbol(Symbol.iterator);
@@ -5022,27 +3904,59 @@ function toString(value) {
   return value == null ? '' : baseToString(value);
 }
 
-module.exports = toString;
+/**
+ * Converts the characters "&", "<", ">", '"', "'", and "\`" in `string` to
+ * their corresponding HTML entities.
+ *
+ * **Note:** No other characters are escaped. To escape additional
+ * characters use a third-party library like [_he_](https://mths.be/he).
+ *
+ * Though the ">" character is escaped for symmetry, characters like
+ * ">" and "/" don't need escaping in HTML and have no special meaning
+ * unless they're part of a tag or unquoted attribute value. See
+ * [Mathias Bynens's article](https://mathiasbynens.be/notes/ambiguous-ampersands)
+ * (under "semi-related fun fact") for more details.
+ *
+ * Backticks are escaped because in IE < 9, they can break out of
+ * attribute values or HTML comments. See [#59](https://html5sec.org/#59),
+ * [#102](https://html5sec.org/#102), [#108](https://html5sec.org/#108), and
+ * [#133](https://html5sec.org/#133) of the
+ * [HTML5 Security Cheatsheet](https://html5sec.org/) for more details.
+ *
+ * When working with HTML you should always
+ * [quote attribute values](http://wonko.com/post/html-escaping) to reduce
+ * XSS vectors.
+ *
+ * @static
+ * @since 0.1.0
+ * @memberOf _
+ * @category String
+ * @param {string} [string=''] The string to escape.
+ * @returns {string} Returns the escaped string.
+ * @example
+ *
+ * _.escape('fred, barney, & pebbles');
+ * // => 'fred, barney, &amp; pebbles'
+ */
+function escape(string) {
+  string = toString(string);
+  return (string && reHasUnescapedHtml.test(string))
+    ? string.replace(reUnescapedHtml, escapeHtmlChar)
+    : string;
+}
+
+module.exports = templateSettings;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],16:[function(require,module,exports){
-/* Built-in method references for those with the same name as other `lodash` methods. */
-var nativeGetPrototype = Object.getPrototypeOf;
+},{"lodash._reinterpolate":4}],9:[function(require,module,exports){
+var overArg = require('./_overArg');
 
-/**
- * Gets the `[[Prototype]]` of `value`.
- *
- * @private
- * @param {*} value The value to query.
- * @returns {null|Object} Returns the `[[Prototype]]`.
- */
-function getPrototype(value) {
-  return nativeGetPrototype(Object(value));
-}
+/** Built-in value references. */
+var getPrototype = overArg(Object.getPrototypeOf, Object);
 
 module.exports = getPrototype;
 
-},{}],17:[function(require,module,exports){
+},{"./_overArg":11}],10:[function(require,module,exports){
 /**
  * Checks if `value` is a host object in IE < 9.
  *
@@ -5064,7 +3978,24 @@ function isHostObject(value) {
 
 module.exports = isHostObject;
 
-},{}],18:[function(require,module,exports){
+},{}],11:[function(require,module,exports){
+/**
+ * Creates a unary function that invokes `func` with its argument transformed.
+ *
+ * @private
+ * @param {Function} func The function to wrap.
+ * @param {Function} transform The argument transform.
+ * @returns {Function} Returns the new function.
+ */
+function overArg(func, transform) {
+  return function(arg) {
+    return func(transform(arg));
+  };
+}
+
+module.exports = overArg;
+
+},{}],12:[function(require,module,exports){
 /**
  * Checks if `value` is object-like. A value is object-like if it's not `null`
  * and has a `typeof` result of "object".
@@ -5095,7 +4026,7 @@ function isObjectLike(value) {
 
 module.exports = isObjectLike;
 
-},{}],19:[function(require,module,exports){
+},{}],13:[function(require,module,exports){
 var getPrototype = require('./_getPrototype'),
     isHostObject = require('./_isHostObject'),
     isObjectLike = require('./isObjectLike');
@@ -5104,10 +4035,11 @@ var getPrototype = require('./_getPrototype'),
 var objectTag = '[object Object]';
 
 /** Used for built-in method references. */
-var objectProto = Object.prototype;
+var funcProto = Function.prototype,
+    objectProto = Object.prototype;
 
 /** Used to resolve the decompiled source of functions. */
-var funcToString = Function.prototype.toString;
+var funcToString = funcProto.toString;
 
 /** Used to check objects for own properties. */
 var hasOwnProperty = objectProto.hasOwnProperty;
@@ -5117,7 +4049,7 @@ var objectCtorString = funcToString.call(Object);
 
 /**
  * Used to resolve the
- * [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+ * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
  * of values.
  */
 var objectToString = objectProto.toString;
@@ -5131,8 +4063,7 @@ var objectToString = objectProto.toString;
  * @since 0.8.0
  * @category Lang
  * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a plain object,
- *  else `false`.
+ * @returns {boolean} Returns `true` if `value` is a plain object, else `false`.
  * @example
  *
  * function Foo() {
@@ -5167,312 +4098,7 @@ function isPlainObject(value) {
 
 module.exports = isPlainObject;
 
-},{"./_getPrototype":16,"./_isHostObject":17,"./isObjectLike":18}],20:[function(require,module,exports){
-'use strict';
-
-/* global mapboxgl */
-if (!mapboxgl) throw new Error('include mapboxgl before mapbox-gl-geocoder.js');
-
-var Typeahead = require('suggestions');
-var debounce = require('lodash.debounce');
-var extend = require('xtend');
-var EventEmitter = require('events').EventEmitter;
-
-// Mapbox Geocoder version
-var API = 'https://api.mapbox.com/geocoding/v5/mapbox.places/';
-
-/**
- * A geocoder component using Mapbox Geocoding APi
- * @class mapboxgl.Geocoder
- *
- * @param {Object} options
- * @param {String} [options.position="top-right"] A string indicating the control's position on the map. Options are `top-right`, `top-left`, `bottom-right`, `bottom-left`
- * @param {String} [options.accessToken=null] Required unless `mapboxgl.accessToken` is set globally
- * @param {string|element} options.container html element to initialize the map in (or element id as string). if no container is passed map.getcontainer() is used instead.
- * @param {Array<Array<number>>} options.proximity If set, search results closer to these coordinates will be given higher priority.
- * @param {Array<Array<number>>} options.bbox Limit results to a given bounding box provided as `[minX, minY, maxX, maxY]`.
- * @param {Number} [options.zoom=16] On geocoded result what zoom level should the map animate to.
- * @param {Boolean} [options.flyTo=true] If false, animating the map to a selected result is disabled.
- * @param {String} [options.placeholder="Search"] Override the default placeholder attribute value.
- * @param {string} options.types a comma seperated list of types that filter results to match those specified. See https://www.mapbox.com/developers/api/geocoding/#filter-type for available types.
- * @param {string} options.country a comma seperated list of country codes to limit results to specified country or countries.
- * @example
- * var geocoder = new mapboxgl.Geocoder();
- * map.addControl(geocoder);
- * @return {Geocoder} `this`
- */
-function Geocoder(options) {
-  this._ev = new EventEmitter();
-  this.options = extend({}, this.options, options);
-}
-
-Geocoder.prototype = mapboxgl.util.inherit(mapboxgl.Control, {
-
-  options: {
-    position: 'top-left',
-    placeholder: 'Search',
-    zoom: 16,
-    flyTo: true
-  },
-
-  onAdd: function(map) {
-    this.request = new XMLHttpRequest();
-
-    this.container = this.options.container ?
-      typeof this.options.container === 'string' ?
-      document.getElementById(this.options.container) :
-      this.options.container :
-      map.getContainer();
-
-    // Template
-    var el = document.createElement('div');
-    el.className = 'mapboxgl-ctrl-geocoder';
-
-    var icon = document.createElement('span');
-    icon.className = 'geocoder-icon geocoder-icon-search';
-
-    var input = this._inputEl = document.createElement('input');
-    input.type = 'text';
-    input.placeholder = this.options.placeholder;
-
-    input.addEventListener('keydown', debounce(function(e) {
-      if (!e.target.value) return this._clearEl.classList.remove('active');
-
-      // TAB, ESC, LEFT, RIGHT, ENTER, UP, DOWN
-      if (e.metaKey || [9, 27, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1) return;
-      this._queryFromInput(e.target.value);
-    }.bind(this)), 200);
-
-    input.addEventListener('change', function(e) {
-      if (e.target.value) this._clearEl.classList.add('active');
-
-      var selected = this._typeahead.selected;
-      if (selected) {
-        if (this.options.flyTo) {
-          if (selected.bbox && selected.context && selected.context.length <= 3 ||
-              selected.bbox && !selected.context) {
-            var bbox = selected.bbox;
-            map.fitBounds([[bbox[0], bbox[1]],[bbox[2], bbox[3]]]);
-          } else {
-            map.flyTo({
-              center: selected.center,
-              zoom: this.options.zoom
-            });
-          }
-        }
-        this._input = selected;
-        this.fire('result', { result: selected });
-      }
-    }.bind(this));
-
-    var actions = document.createElement('div');
-    actions.classList.add('geocoder-pin-right');
-
-    var clear = this._clearEl = document.createElement('button');
-    clear.className = 'geocoder-icon geocoder-icon-close';
-    clear.addEventListener('click', this._clear.bind(this));
-
-    var loading = this._loadingEl = document.createElement('span');
-    loading.className = 'geocoder-icon geocoder-icon-loading';
-
-    actions.appendChild(clear);
-    actions.appendChild(loading);
-
-    el.appendChild(icon);
-    el.appendChild(input);
-    el.appendChild(actions);
-
-    this.container.appendChild(el);
-
-    // Override the control being added to control containers
-    if (this.options.container) this.options.position = false;
-
-    this._typeahead = new Typeahead(input, [], { filter: false });
-    this._typeahead.getItemValue = function(item) { return item.place_name; };
-
-    return el;
-  },
-
-  _geocode: function(q, callback) {
-    this._loadingEl.classList.add('active');
-    this.fire('loading');
-
-    var options = [];
-    if (this.options.proximity) options.push('proximity=' + this.options.proximity.join());
-    if (this.options.bbox) options.push('bbox=' + this.options.bbox.join());
-    if (this.options.country) options.push('country=' + this.options.country);
-    if (this.options.types) options.push('types=' + this.options.types);
-
-    var accessToken = this.options.accessToken ? this.options.accessToken : mapboxgl.accessToken;
-    options.push('access_token=' + accessToken);
-
-    this.request.abort();
-    this.request.open('GET', API + encodeURIComponent(q.trim()) + '.json?' + options.join('&'), true);
-    this.request.onload = function() {
-      this._loadingEl.classList.remove('active');
-      if (this.request.status >= 200 && this.request.status < 400) {
-        var data = JSON.parse(this.request.responseText);
-        if (data.features.length) {
-          this._clearEl.classList.add('active');
-        } else {
-          this._clearEl.classList.remove('active');
-          this._typeahead.selected = null;
-        }
-
-        this.fire('results', { results: data.features });
-        this._typeahead.update(data.features);
-        return callback(data.features);
-      } else {
-        this.fire('error', { error: JSON.parse(this.request.responseText).message });
-      }
-    }.bind(this);
-
-    this.request.onerror = function() {
-      this._loadingEl.classList.remove('active');
-      this.fire('error', { error: JSON.parse(this.request.responseText).message });
-    }.bind(this);
-
-    this.request.send();
-  },
-
-  _queryFromInput: function(q) {
-    q = q.trim();
-    if (!q) this._clear();
-    if (q.length > 2) {
-      this._geocode(q, function(results) {
-        this._results = results;
-      }.bind(this));
-    }
-  },
-
-  _change: function() {
-    var onChange = document.createEvent('HTMLEvents');
-    onChange.initEvent('change', true, false);
-    this._inputEl.dispatchEvent(onChange);
-  },
-
-  _query: function(input) {
-    if (!input) return;
-    if (typeof input === 'object' && input.length) {
-      input = [
-        mapboxgl.util.wrap(input[0], -180, 180),
-        mapboxgl.util.wrap(input[1], -180, 180)
-      ].join();
-    }
-
-    this._geocode(input, function(results) {
-      if (!results.length) return;
-      var result = results[0];
-      this._results = results;
-      this._typeahead.selected = result;
-      this._inputEl.value = result.place_name;
-      this._change();
-    }.bind(this));
-  },
-
-  _setInput: function(input) {
-    if (!input) return;
-    if (typeof input === 'object' && input.length) {
-      input = [
-        mapboxgl.util.wrap(input[0], -180, 180),
-        mapboxgl.util.wrap(input[1], -180, 180)
-      ].join();
-    }
-
-    // Set input value to passed value and clear everything else.
-    this._inputEl.value = input;
-    this._input = null;
-    this._typeahead.selected = null;
-    this._typeahead.clear();
-    this._change();
-  },
-
-  _clear: function() {
-    this._input = null;
-    this._inputEl.value = '';
-    this._typeahead.selected = null;
-    this._typeahead.clear();
-    this._change();
-    this._inputEl.focus();
-    this._clearEl.classList.remove('active');
-    this.fire('clear');
-  },
-
-  /**
-   * Return the input
-   * @returns {Object} input
-   */
-  getResult: function() {
-    return this._input;
-  },
-
-  /**
-   * Set & query the input
-   * @param {Array|String} query An array of coordinates [lng, lat] or location name as a string.
-   * @returns {Geocoder} this
-   */
-  query: function(query) {
-    this._query(query);
-    return this;
-  },
-
-  /**
-   * Set input
-   * @param {Array|String} value An array of coordinates [lng, lat] or location name as a string. Calling this function just sets the input and does not trigger an API request.
-   * @returns {Geocoder} this
-   */
-  setInput: function(value) {
-    this._setInput(value);
-    return this;
-  },
-
-  /**
-   * Subscribe to events that happen within the plugin.
-   * @param {String} type name of event. Available events and the data passed into their respective event objects are:
-   *
-   * - __clear__ `Emitted when the input is cleared`
-   * - __loading__ `Emitted when the geocoder is looking up a query`
-   * - __results__ `{ results } Fired when the geocoder returns a response`
-   * - __result__ `{ result } Fired when input is set`
-   * - __error__ `{ error } Error as string
-   * @param {Function} fn function that's called when the event is emitted.
-   * @returns {Geocoder} this;
-   */
-  on: function(type, fn) {
-    this._ev.on(type, fn);
-    return this;
-  },
-
-  /**
-   * Fire an event
-   * @param {String} type event name.
-   * @param {Object} data event data to pass to the function subscribed.
-   * @returns {Geocoder} this
-   */
-  fire: function(type, data) {
-    this._ev.emit(type, data);
-    return this;
-  },
-
-  /**
-   * Remove an event
-   * @returns {Geocoder} this
-   * @param {String} type Event name.
-   * @param {Function} fn Function that should unsubscribe to the event emitted.
-   */
-  off: function(type, fn) {
-    this._ev.removeListener(type, fn);
-    return this;
-  }
-});
-
-if (window.mapboxgl) {
-  mapboxgl.Geocoder = Geocoder;
-} else if (typeof module !== 'undefined') {
-  module.exports = Geocoder;
-}
-
-},{"events":2,"lodash.debounce":7,"suggestions":30,"xtend":37}],21:[function(require,module,exports){
+},{"./_getPrototype":9,"./_isHostObject":10,"./isObjectLike":12}],14:[function(require,module,exports){
 'use strict';
 
 /**
@@ -5627,7 +4253,7 @@ if (typeof module === 'object' && module.exports) {
     module.exports = polyline;
 }
 
-},{}],22:[function(require,module,exports){
+},{}],15:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -5651,7 +4277,7 @@ var thunk = createThunkMiddleware();
 thunk.withExtraArgument = createThunkMiddleware;
 
 exports['default'] = thunk;
-},{}],23:[function(require,module,exports){
+},{}],16:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -5710,7 +4336,7 @@ function applyMiddleware() {
     };
   };
 }
-},{"./compose":26}],24:[function(require,module,exports){
+},{"./compose":19}],17:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -5762,7 +4388,7 @@ function bindActionCreators(actionCreators, dispatch) {
   }
   return boundActionCreators;
 }
-},{}],25:[function(require,module,exports){
+},{}],18:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -5890,7 +4516,7 @@ function combineReducers(reducers) {
     return hasChanged ? nextState : state;
   };
 }
-},{"./createStore":27,"./utils/warning":29,"lodash/isPlainObject":19}],26:[function(require,module,exports){
+},{"./createStore":20,"./utils/warning":22,"lodash/isPlainObject":13}],19:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -5931,7 +4557,7 @@ function compose() {
     if (typeof _ret === "object") return _ret.v;
   }
 }
-},{}],27:[function(require,module,exports){
+},{}],20:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -6194,7 +4820,7 @@ function createStore(reducer, initialState, enhancer) {
     replaceReducer: replaceReducer
   }, _ref2[_symbolObservable2["default"]] = observable, _ref2;
 }
-},{"lodash/isPlainObject":19,"symbol-observable":33}],28:[function(require,module,exports){
+},{"lodash/isPlainObject":13,"symbol-observable":26}],21:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -6241,7 +4867,7 @@ exports.combineReducers = _combineReducers2["default"];
 exports.bindActionCreators = _bindActionCreators2["default"];
 exports.applyMiddleware = _applyMiddleware2["default"];
 exports.compose = _compose2["default"];
-},{"./applyMiddleware":23,"./bindActionCreators":24,"./combineReducers":25,"./compose":26,"./createStore":27,"./utils/warning":29}],29:[function(require,module,exports){
+},{"./applyMiddleware":16,"./bindActionCreators":17,"./combineReducers":18,"./compose":19,"./createStore":20,"./utils/warning":22}],22:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -6267,7 +4893,7 @@ function warning(message) {
   } catch (e) {}
   /* eslint-enable no-empty */
 }
-},{}],30:[function(require,module,exports){
+},{}],23:[function(require,module,exports){
 'use strict';
 
 /**
@@ -6326,7 +4952,7 @@ function warning(message) {
 var Suggestions = require('./src/suggestions');
 window.Suggestions = module.exports = Suggestions;
 
-},{"./src/suggestions":32}],31:[function(require,module,exports){
+},{"./src/suggestions":25}],24:[function(require,module,exports){
 'Use strict';
 
 var List = function(component) {
@@ -6413,7 +5039,7 @@ List.prototype.next = function() {
 
 module.exports = List;
 
-},{}],32:[function(require,module,exports){
+},{}],25:[function(require,module,exports){
 'use strict';
 
 var extend = require('xtend');
@@ -6603,7 +5229,7 @@ Suggestions.prototype.getItemValue = function(item) {
 
 module.exports = Suggestions;
 
-},{"./list":31,"fuzzy":3,"xtend":37}],33:[function(require,module,exports){
+},{"./list":24,"fuzzy":3,"xtend":30}],26:[function(require,module,exports){
 (function (global){
 /* global window */
 'use strict';
@@ -6611,7 +5237,7 @@ module.exports = Suggestions;
 module.exports = require('./ponyfill')(global || window || this);
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./ponyfill":34}],34:[function(require,module,exports){
+},{"./ponyfill":27}],27:[function(require,module,exports){
 'use strict';
 
 module.exports = function symbolObservablePonyfill(root) {
@@ -6632,7 +5258,7 @@ module.exports = function symbolObservablePonyfill(root) {
 	return result;
 };
 
-},{}],35:[function(require,module,exports){
+},{}],28:[function(require,module,exports){
 var each = require('turf-meta').coordEach;
 
 /**
@@ -6702,7 +5328,7 @@ module.exports = function(layer) {
     return extent;
 };
 
-},{"turf-meta":36}],36:[function(require,module,exports){
+},{"turf-meta":29}],29:[function(require,module,exports){
 /**
  * Lazily iterate over coordinates in any GeoJSON object, similar to
  * Array.forEach.
@@ -6842,7 +5468,7 @@ function propReduce(layer, callback, memo) {
 }
 module.exports.propReduce = propReduce;
 
-},{}],37:[function(require,module,exports){
+},{}],30:[function(require,module,exports){
 module.exports = extend
 
 var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -6863,7 +5489,7 @@ function extend() {
     return target
 }
 
-},{}],38:[function(require,module,exports){
+},{}],31:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -7274,7 +5900,7 @@ function eventEmit(type, data) {
   };
 }
 
-},{"../constants/action_types":39,"../utils":45}],39:[function(require,module,exports){
+},{"../constants/action_types":32,"../utils":39}],32:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -7297,7 +5923,315 @@ var ROUTE_INDEX = exports.ROUTE_INDEX = 'ROUTE_INDEX';
 var SET_OPTIONS = exports.SET_OPTIONS = 'SET_OPTIONS';
 var WAYPOINTS = exports.WAYPOINTS = 'WAYPOINTS';
 
-},{}],40:[function(require,module,exports){
+},{}],33:[function(require,module,exports){
+'use strict';
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+
+var Typeahead = require('suggestions');
+var debounce = require('lodash.debounce');
+var extend = require('xtend');
+var EventEmitter = require('events').EventEmitter;
+
+// Mapbox Geocoder version
+var API = 'https://api.mapbox.com/geocoding/v5/mapbox.places/';
+
+/**
+ * A geocoder component using Mapbox Geocoding API
+ * @class mapboxgl.Geocoder
+ *
+ * @param {Object} options
+ * @param {String} [options.position="top-right"] A string indicating the control's position on the map. Options are `top-right`, `top-left`, `bottom-right`, `bottom-left`
+ * @param {String} [options.accessToken=null] Required unless `mapboxgl.accessToken` is set globally
+ * @param {string|element} options.container The HTML element to append the Geocoder input to. if container is not specified, `map.getcontainer()` is used.
+ * @param {Array<number>} options.proximity If set, search results closer to these coordinates will be given higher priority.
+ * @param {Array<number>} options.bbox Limit results to a given bounding box provided as `[minX, minY, maxX, maxY]`.
+ * @param {Number} [options.zoom=16] On geocoded result what zoom level should the map animate to.
+ * @param {Boolean} [options.flyTo=true] If false, animating the map to a selected result is disabled.
+ * @param {String} [options.placeholder="Search"] Override the default placeholder attribute value.
+ * @param {string} options.types a comma seperated list of types that filter results to match those specified. See https://www.mapbox.com/developers/api/geocoding/#filter-type for available types.
+ * @param {string} options.country a comma seperated list of country codes to limit results to specified country or countries.
+ * @example
+ * var geocoder = new mapboxgl.Geocoder();
+ * map.addControl(geocoder);
+ * @return {Geocoder} `this`
+ */
+function Geocoder(options) {
+  this._ev = new EventEmitter();
+  this.options = extend({}, this.options, options);
+}
+
+Geocoder.prototype = {
+
+  options: {
+    position: 'top-left',
+    placeholder: 'Search',
+    zoom: 16,
+    flyTo: true
+  },
+
+  addTo: function addTo(map) {
+    this._map = map;
+    var container = this._container = this.onAdd(map);
+    if (this.options && this.options.position) {
+      var pos = this.options.position;
+      var corner = map._controlCorners[pos];
+      container.className += ' mapboxgl-ctrl';
+      if (pos.indexOf('bottom') !== -1) {
+        corner.insertBefore(container, corner.firstChild);
+      } else {
+        corner.appendChild(container);
+      }
+    }
+
+    return this;
+  },
+
+  onAdd: function onAdd(map) {
+    this.request = new XMLHttpRequest();
+
+    this.container = this.options.container ? typeof this.options.container === 'string' ? document.getElementById(this.options.container) : this.options.container : map.getContainer();
+
+    // Template
+    var el = document.createElement('div');
+    el.className = 'mapboxgl-ctrl-geocoder';
+
+    var icon = document.createElement('span');
+    icon.className = 'geocoder-icon geocoder-icon-search';
+
+    var input = this._inputEl = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = this.options.placeholder;
+
+    input.addEventListener('keydown', debounce(function (e) {
+      if (!e.target.value) return this._clearEl.classList.remove('active');
+
+      // TAB, ESC, LEFT, RIGHT, ENTER, UP, DOWN
+      if (e.metaKey || [9, 27, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1) return;
+      this._queryFromInput(e.target.value);
+    }.bind(this)), 200);
+
+    input.addEventListener('change', function (e) {
+      if (e.target.value) this._clearEl.classList.add('active');
+
+      var selected = this._typeahead.selected;
+      if (selected) {
+        if (this.options.flyTo) {
+          if (selected.bbox && selected.context && selected.context.length <= 3 || selected.bbox && !selected.context) {
+            var bbox = selected.bbox;
+            map.fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]]);
+          } else {
+            map.flyTo({
+              center: selected.center,
+              zoom: this.options.zoom
+            });
+          }
+        }
+        this._input = selected;
+        this.fire('result', { result: selected });
+      }
+    }.bind(this));
+
+    var actions = document.createElement('div');
+    actions.classList.add('geocoder-pin-right');
+
+    var clear = this._clearEl = document.createElement('button');
+    clear.className = 'geocoder-icon geocoder-icon-close';
+    clear.addEventListener('click', this._clear.bind(this));
+
+    var loading = this._loadingEl = document.createElement('span');
+    loading.className = 'geocoder-icon geocoder-icon-loading';
+
+    actions.appendChild(clear);
+    actions.appendChild(loading);
+
+    el.appendChild(icon);
+    el.appendChild(input);
+    el.appendChild(actions);
+
+    this.container.appendChild(el);
+
+    // Override the control being added to control containers
+    if (this.options.container) this.options.position = false;
+
+    this._typeahead = new Typeahead(input, [], { filter: false });
+    this._typeahead.getItemValue = function (item) {
+      return item.place_name;
+    };
+
+    return el;
+  },
+
+  _geocode: function _geocode(q, callback) {
+    this._loadingEl.classList.add('active');
+    this.fire('loading');
+
+    var options = [];
+    if (this.options.proximity) options.push('proximity=' + this.options.proximity.join());
+    if (this.options.bbox) options.push('bbox=' + this.options.bbox.join());
+    if (this.options.country) options.push('country=' + this.options.country);
+    if (this.options.types) options.push('types=' + this.options.types);
+
+    var accessToken = this.options.accessToken ? this.options.accessToken : mapboxgl.accessToken;
+    options.push('access_token=' + accessToken);
+
+    this.request.abort();
+    this.request.open('GET', API + encodeURIComponent(q.trim()) + '.json?' + options.join('&'), true);
+    this.request.onload = function () {
+      this._loadingEl.classList.remove('active');
+      if (this.request.status >= 200 && this.request.status < 400) {
+        var data = JSON.parse(this.request.responseText);
+        if (data.features.length) {
+          this._clearEl.classList.add('active');
+        } else {
+          this._clearEl.classList.remove('active');
+          this._typeahead.selected = null;
+        }
+
+        this.fire('results', { results: data.features });
+        this._typeahead.update(data.features);
+        return callback(data.features);
+      } else {
+        this.fire('error', { error: JSON.parse(this.request.responseText).message });
+      }
+    }.bind(this);
+
+    this.request.onerror = function () {
+      this._loadingEl.classList.remove('active');
+      this.fire('error', { error: JSON.parse(this.request.responseText).message });
+    }.bind(this);
+
+    this.request.send();
+  },
+
+  _queryFromInput: function _queryFromInput(q) {
+    q = q.trim();
+    if (!q) this._clear();
+    if (q.length > 2) {
+      this._geocode(q, function (results) {
+        this._results = results;
+      }.bind(this));
+    }
+  },
+
+  _change: function _change() {
+    var onChange = document.createEvent('HTMLEvents');
+    onChange.initEvent('change', true, false);
+    this._inputEl.dispatchEvent(onChange);
+  },
+
+  _query: function _query(input) {
+    if (!input) return;
+    if ((typeof input === 'undefined' ? 'undefined' : _typeof(input)) === 'object' && input.length) {
+      input = [mapboxgl.util.wrap(input[0], -180, 180), mapboxgl.util.wrap(input[1], -180, 180)].join();
+    }
+
+    this._geocode(input, function (results) {
+      if (!results.length) return;
+      var result = results[0];
+      this._results = results;
+      this._typeahead.selected = result;
+      this._inputEl.value = result.place_name;
+      this._change();
+    }.bind(this));
+  },
+
+  _setInput: function _setInput(input) {
+    if (!input) return;
+    if ((typeof input === 'undefined' ? 'undefined' : _typeof(input)) === 'object' && input.length) {
+      input = [mapboxgl.util.wrap(input[0], -180, 180), mapboxgl.util.wrap(input[1], -180, 180)].join();
+    }
+
+    // Set input value to passed value and clear everything else.
+    this._inputEl.value = input;
+    this._input = null;
+    this._typeahead.selected = null;
+    this._typeahead.clear();
+    this._change();
+  },
+
+  _clear: function _clear() {
+    this._input = null;
+    this._inputEl.value = '';
+    this._typeahead.selected = null;
+    this._typeahead.clear();
+    this._change();
+    this._inputEl.focus();
+    this._clearEl.classList.remove('active');
+    this.fire('clear');
+  },
+
+  /**
+   * Return the input
+   * @returns {Object} input
+   */
+  getResult: function getResult() {
+    return this._input;
+  },
+
+  /**
+   * Set & query the input
+   * @param {Array|String} query An array of coordinates [lng, lat] or location name as a string.
+   * @returns {Geocoder} this
+   */
+  query: function query(_query2) {
+    this._query(_query2);
+    return this;
+  },
+
+  /**
+   * Set input
+   * @param {Array|String} value An array of coordinates [lng, lat] or location name as a string. Calling this function just sets the input and does not trigger an API request.
+   * @returns {Geocoder} this
+   */
+  setInput: function setInput(value) {
+    this._setInput(value);
+    return this;
+  },
+
+  /**
+   * Subscribe to events that happen within the plugin.
+   * @param {String} type name of event. Available events and the data passed into their respective event objects are:
+   *
+   * - __clear__ `Emitted when the input is cleared`
+   * - __loading__ `Emitted when the geocoder is looking up a query`
+   * - __results__ `{ results } Fired when the geocoder returns a response`
+   * - __result__ `{ result } Fired when input is set`
+   * - __error__ `{ error } Error as string
+   * @param {Function} fn function that's called when the event is emitted.
+   * @returns {Geocoder} this;
+   */
+  on: function on(type, fn) {
+    this._ev.on(type, fn);
+    return this;
+  },
+
+  /**
+   * Fire an event
+   * @param {String} type event name.
+   * @param {Object} data event data to pass to the function subscribed.
+   * @returns {Geocoder} this
+   */
+  fire: function fire(type, data) {
+    this._ev.emit(type, data);
+    return this;
+  },
+
+  /**
+   * Remove an event
+   * @returns {Geocoder} this
+   * @param {String} type Event name.
+   * @param {Function} fn Function that should unsubscribe to the event emitted.
+   */
+  off: function off(type, fn) {
+    this._ev.removeListener(type, fn);
+    return this;
+  }
+};
+
+module.exports = Geocoder;
+
+},{"events":2,"lodash.debounce":5,"suggestions":23,"xtend":30}],34:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -7306,7 +6240,9 @@ Object.defineProperty(exports, "__esModule", {
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-require('mapbox-gl-geocoder');
+var _geocoder = require('./geocoder');
+
+var _geocoder2 = _interopRequireDefault(_geocoder);
 
 var _lodash = require('lodash.template');
 
@@ -7403,7 +6339,7 @@ var Inputs = function () {
       var geocoder = _store$getState3.geocoder;
 
 
-      this.originInput = new mapboxgl.Geocoder(Object.assign({}, {
+      this.originInput = new _geocoder2.default(Object.assign({}, {
         flyTo: false,
         placeholder: 'Choose a starting place',
         container: this.container.querySelector('#mapbox-directions-origin-input')
@@ -7411,7 +6347,7 @@ var Inputs = function () {
 
       this.map.addControl(this.originInput);
 
-      this.destinationInput = new mapboxgl.Geocoder(Object.assign({}, {
+      this.destinationInput = new _geocoder2.default(Object.assign({}, {
         flyTo: false,
         placeholder: 'Choose destination',
         container: this.container.querySelector('#mapbox-directions-destination-input')
@@ -7499,7 +6435,7 @@ var Inputs = function () {
 
 exports.default = Inputs;
 
-},{"lodash.isequal":9,"lodash.template":13,"mapbox-gl-geocoder":20,"turf-extent":35}],41:[function(require,module,exports){
+},{"./geocoder":33,"lodash.isequal":6,"lodash.template":7,"turf-extent":28}],35:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -7625,7 +6561,7 @@ var Instructions = function () {
 
 exports.default = Instructions;
 
-},{"../utils":45,"lodash.isequal":9,"lodash.template":13}],42:[function(require,module,exports){
+},{"../utils":39,"lodash.isequal":6,"lodash.template":7}],36:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -7672,12 +6608,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-if (!mapboxgl) throw new Error('include mapboxgl before mapbox-gl-directions.js');
-
 var storeWithMiddleware = (0, _redux.applyMiddleware)(_reduxThunk2.default)(_redux.createStore);
 var store = storeWithMiddleware(_reducers2.default);
 
@@ -7686,29 +6616,42 @@ var store = storeWithMiddleware(_reducers2.default);
 
 // Controls
 
-var Directions = function (_mapboxgl$Control) {
-  _inherits(Directions, _mapboxgl$Control);
-
+var Directions = function () {
   function Directions(options) {
     _classCallCheck(this, Directions);
 
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(Directions).call(this));
+    this.actions = (0, _redux.bindActionCreators)(actions, store.dispatch);
+    this.actions.setOptions(options || {});
 
-    _this.actions = (0, _redux.bindActionCreators)(actions, store.dispatch);
-    _this.actions.setOptions(options || {});
-
-    _this.onDragDown = _this._onDragDown.bind(_this);
-    _this.onDragMove = _this._onDragMove.bind(_this);
-    _this.onDragUp = _this._onDragUp.bind(_this);
-    _this.move = _this._move.bind(_this);
-    _this.onClick = _this._onClick.bind(_this);
-    return _this;
+    this.onDragDown = this._onDragDown.bind(this);
+    this.onDragMove = this._onDragMove.bind(this);
+    this.onDragUp = this._onDragUp.bind(this);
+    this.move = this._move.bind(this);
+    this.onClick = this._onClick.bind(this);
   }
 
   _createClass(Directions, [{
+    key: 'addTo',
+    value: function addTo(map) {
+      this._map = map;
+      var container = this._container = this.onAdd(map);
+      if (this.options && this.options.position) {
+        var pos = this.options.position;
+        var corner = map._controlCorners[pos];
+        container.className += ' mapboxgl-ctrl';
+        if (pos.indexOf('bottom') !== -1) {
+          corner.insertBefore(container, corner.firstChild);
+        } else {
+          corner.appendChild(container);
+        }
+      }
+
+      return this;
+    }
+  }, {
     key: 'onAdd',
     value: function onAdd(map) {
-      var _this2 = this;
+      var _this = this;
 
       this.map = map;
 
@@ -7738,13 +6681,27 @@ var Directions = function (_mapboxgl$Control) {
 
       this.subscribedActions();
       this.map.on('style.load', function () {
-        return _this2.mapState();
+        return _this.mapState();
       });
+    }
+
+    /**
+     * Removes the control from the map it has been added to.
+     *
+     * @returns {Control} `this`
+     */
+
+  }, {
+    key: 'remove',
+    value: function remove() {
+      this.container.parentNode.removeChild(this.container);
+      this.map = null;
+      return this;
     }
   }, {
     key: 'mapState',
     value: function mapState() {
-      var _this3 = this;
+      var _this2 = this;
 
       var _store$getState2 = store.getState();
 
@@ -7768,11 +6725,11 @@ var Directions = function (_mapboxgl$Control) {
 
       // Add direction specific styles to the map
       _directions_style2.default.forEach(function (style) {
-        return _this3.map.addLayer(style);
+        return _this2.map.addLayer(style);
       });
 
       if (styles && styles.length) styles.forEach(function (style) {
-        return _this3.map.addLayer(style);
+        return _this2.map.addLayer(style);
       });
 
       if (interactive) {
@@ -7787,7 +6744,7 @@ var Directions = function (_mapboxgl$Control) {
   }, {
     key: 'subscribedActions',
     value: function subscribedActions() {
-      var _this4 = this;
+      var _this3 = this;
 
       store.subscribe(function () {
         var _store$getState3 = store.getState();
@@ -7841,13 +6798,13 @@ var Directions = function (_mapboxgl$Control) {
           });
         }
 
-        if (_this4.map.style) _this4.map.getSource('directions').setData(geojson);
+        if (_this3.map.style) _this3.map.getSource('directions').setData(geojson);
       });
     }
   }, {
     key: '_onClick',
     value: function _onClick(e) {
-      var _this5 = this;
+      var _this4 = this;
 
       var _store$getState4 = store.getState();
 
@@ -7868,7 +6825,7 @@ var Directions = function (_mapboxgl$Control) {
           // Remove any waypoints
           features.forEach(function (f) {
             if (f.layer.id === 'directions-waypoint-point') {
-              _this5.actions.removeWaypoint(f);
+              _this4.actions.removeWaypoint(f);
             }
           });
 
@@ -7885,7 +6842,7 @@ var Directions = function (_mapboxgl$Control) {
   }, {
     key: '_move',
     value: function _move(e) {
-      var _this6 = this;
+      var _this5 = this;
 
       var _store$getState5 = store.getState();
 
@@ -7905,9 +6862,9 @@ var Directions = function (_mapboxgl$Control) {
         // Add a possible waypoint marker when hovering over the active route line
         features.forEach(function (feature) {
           if (feature.layer.id === 'directions-route-line') {
-            _this6.actions.hoverMarker([e.lngLat.lng, e.lngLat.lat]);
+            _this5.actions.hoverMarker([e.lngLat.lng, e.lngLat.lat]);
           } else if (hoverMarker.geometry) {
-            _this6.actions.hoverMarker(null);
+            _this5.actions.hoverMarker(null);
           }
         });
       } else if (this.isCursorOverPoint) {
@@ -8171,11 +7128,11 @@ var Directions = function (_mapboxgl$Control) {
   }]);
 
   return Directions;
-}(mapboxgl.Control);
+}();
 
 exports.default = Directions;
 
-},{"./actions":38,"./controls/inputs":40,"./controls/instructions":41,"./directions_style":43,"./reducers":44,"./utils":45,"polyline":21,"redux":28,"redux-thunk":22}],43:[function(require,module,exports){
+},{"./actions":31,"./controls/inputs":34,"./controls/instructions":35,"./directions_style":37,"./reducers":38,"./utils":39,"polyline":14,"redux":21,"redux-thunk":15}],37:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -8291,7 +7248,7 @@ var style = [{
 
 exports.default = style;
 
-},{}],44:[function(require,module,exports){
+},{}],38:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -8436,7 +7393,7 @@ function data() {
 
 exports.default = data;
 
-},{"../constants/action_types.js":39}],45:[function(require,module,exports){
+},{"../constants/action_types.js":32}],39:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {

--- a/dist/mapbox-gl-directions.js
+++ b/dist/mapbox-gl-directions.js
@@ -6293,7 +6293,7 @@ var Inputs = function () {
     this.container = el;
     this.actions = actions;
     this.store = store;
-    this.map = map;
+    this._map = map;
 
     this.onAdd();
     this.render();
@@ -6316,9 +6316,9 @@ var Inputs = function () {
           features: [origin, destination]
         });
 
-        this.map.fitBounds([[bb[0], bb[1]], [bb[2], bb[3]]], { padding: 80 });
+        this._map.fitBounds([[bb[0], bb[1]], [bb[2], bb[3]]], { padding: 80 });
       } else {
-        this.map.flyTo({ center: coords });
+        this._map.flyTo({ center: coords });
       }
     }
   }, {
@@ -6345,7 +6345,7 @@ var Inputs = function () {
         container: this.container.querySelector('#mapbox-directions-origin-input')
       }, geocoder));
 
-      this.map.addControl(this.originInput);
+      this._map.addControl(this.originInput);
 
       this.destinationInput = new _geocoder2.default(Object.assign({}, {
         flyTo: false,
@@ -6353,7 +6353,7 @@ var Inputs = function () {
         container: this.container.querySelector('#mapbox-directions-destination-input')
       }, geocoder));
 
-      this.map.addControl(this.destinationInput);
+      this._map.addControl(this.destinationInput);
 
       this.originInput.on('result', function (e) {
         var coords = e.result.center;
@@ -6481,7 +6481,7 @@ var Instructions = function () {
     this.container = el;
     this.actions = actions;
     this.store = store;
-    this.map = map;
+    this._map = map;
     this.directions = {};
     this.render();
   }
@@ -6536,7 +6536,7 @@ var Instructions = function () {
             });
 
             el.addEventListener('click', function () {
-              _this.map.flyTo({
+              _this._map.flyTo({
                 center: [lng, lat],
                 zoom: 16
               });
@@ -6653,7 +6653,7 @@ var Directions = function () {
     value: function onAdd(map) {
       var _this = this;
 
-      this.map = map;
+      this._map = map;
 
       var _store$getState = store.getState();
 
@@ -6661,12 +6661,12 @@ var Directions = function () {
       var controls = _store$getState.controls;
 
 
-      this.container = container ? typeof container === 'string' ? document.getElementById(container) : container : this.map.getContainer();
+      this.container = container ? typeof container === 'string' ? document.getElementById(container) : container : this._map.getContainer();
 
       // Add controls to the page
       var inputEl = document.createElement('div');
       inputEl.className = 'directions-control directions-control-inputs';
-      new _inputs2.default(inputEl, store, this.actions, this.map);
+      new _inputs2.default(inputEl, store, this.actions, this._map);
 
       var directionsEl = document.createElement('div');
       directionsEl.className = 'directions-control-directions-container';
@@ -6674,13 +6674,13 @@ var Directions = function () {
       new _instructions2.default(directionsEl, store, {
         hoverMarker: this.actions.hoverMarker,
         setRouteIndex: this.actions.setRouteIndex
-      }, this.map);
+      }, this._map);
 
       if (controls.inputs) this.container.appendChild(inputEl);
       if (controls.instructions) this.container.appendChild(directionsEl);
 
       this.subscribedActions();
-      this.map.on('style.load', function () {
+      this._map.on('style.load', function () {
         return _this.mapState();
       });
     }
@@ -6695,7 +6695,7 @@ var Directions = function () {
     key: 'remove',
     value: function remove() {
       this.container.parentNode.removeChild(this.container);
-      this.map = null;
+      this._map = null;
       return this;
     }
   }, {
@@ -6721,24 +6721,24 @@ var Directions = function () {
       });
 
       // Add and set data theme layer/style
-      this.map.addSource('directions', geojson);
+      this._map.addSource('directions', geojson);
 
       // Add direction specific styles to the map
       _directions_style2.default.forEach(function (style) {
-        return _this2.map.addLayer(style);
+        return _this2._map.addLayer(style);
       });
 
       if (styles && styles.length) styles.forEach(function (style) {
-        return _this2.map.addLayer(style);
+        return _this2._map.addLayer(style);
       });
 
       if (interactive) {
-        this.map.on('mousedown', this.onDragDown);
-        this.map.on('mousemove', this.move);
-        this.map.on('click', this.onClick);
+        this._map.on('mousedown', this.onDragDown);
+        this._map.on('mousemove', this.move);
+        this._map.on('click', this.onClick);
 
-        this.map.on('touchstart', this.move);
-        this.map.on('touchstart', this.onDragDown);
+        this._map.on('touchstart', this.move);
+        this._map.on('touchstart', this.onDragDown);
       }
     }
   }, {
@@ -6798,7 +6798,7 @@ var Directions = function () {
           });
         }
 
-        if (_this3.map.style) _this3.map.getSource('directions').setData(geojson);
+        if (_this3._map.style) _this3._map.getSource('directions').setData(geojson);
       });
     }
   }, {
@@ -6816,7 +6816,7 @@ var Directions = function () {
         this.actions.setOriginFromCoordinates(coords);
       } else {
 
-        var features = this.map.queryRenderedFeatures(e.point, {
+        var features = this._map.queryRenderedFeatures(e.point, {
           layers: ['directions-origin-point', 'directions-destination-point', 'directions-waypoint-point', 'directions-route-line-alt']
         });
 
@@ -6835,7 +6835,7 @@ var Directions = function () {
           }
         } else {
           this.actions.setDestinationFromCoordinates(coords);
-          this.map.flyTo({ center: coords });
+          this._map.flyTo({ center: coords });
         }
       }
     }
@@ -6849,15 +6849,15 @@ var Directions = function () {
       var hoverMarker = _store$getState5.hoverMarker;
 
 
-      var features = this.map.queryRenderedFeatures(e.point, {
+      var features = this._map.queryRenderedFeatures(e.point, {
         layers: ['directions-route-line-alt', 'directions-route-line', 'directions-origin-point', 'directions-destination-point', 'directions-hover-point']
       });
 
-      this.map.getCanvas().style.cursor = features.length ? 'pointer' : '';
+      this._map.getCanvas().style.cursor = features.length ? 'pointer' : '';
 
       if (features.length) {
         this.isCursorOverPoint = features[0];
-        this.map.dragPan.disable();
+        this._map.dragPan.disable();
 
         // Add a possible waypoint marker when hovering over the active route line
         features.forEach(function (feature) {
@@ -6869,7 +6869,7 @@ var Directions = function () {
         });
       } else if (this.isCursorOverPoint) {
         this.isCursorOverPoint = false;
-        this.map.dragPan.enable();
+        this._map.dragPan.enable();
       }
     }
   }, {
@@ -6877,13 +6877,13 @@ var Directions = function () {
     value: function _onDragDown() {
       if (!this.isCursorOverPoint) return;
       this.isDragging = this.isCursorOverPoint;
-      this.map.getCanvas().style.cursor = 'grab';
+      this._map.getCanvas().style.cursor = 'grab';
 
-      this.map.on('mousemove', this.onDragMove);
-      this.map.on('mouseup', this.onDragUp);
+      this._map.on('mousemove', this.onDragMove);
+      this._map.on('mouseup', this.onDragUp);
 
-      this.map.on('touchmove', this.onDragMove);
-      this.map.on('touchend', this.onDragUp);
+      this._map.on('touchmove', this.onDragMove);
+      this._map.on('touchend', this.onDragUp);
     }
   }, {
     key: '_onDragMove',
@@ -6931,13 +6931,13 @@ var Directions = function () {
       }
 
       this.isDragging = false;
-      this.map.getCanvas().style.cursor = '';
+      this._map.getCanvas().style.cursor = '';
 
-      this.map.off('touchmove', this.onDragMove);
-      this.map.off('touchend', this.onDragUp);
+      this._map.off('touchmove', this.onDragMove);
+      this._map.off('touchend', this.onDragUp);
 
-      this.map.off('mousemove', this.onDragMove);
-      this.map.off('mouseup', this.onDragUp);
+      this._map.off('mousemove', this.onDragMove);
+      this._map.off('mouseup', this.onDragUp);
     }
 
     // API Methods
@@ -6953,19 +6953,19 @@ var Directions = function () {
     key: 'interactive',
     value: function interactive(state) {
       if (state) {
-        this.map.on('touchstart', this.move);
-        this.map.on('touchstart', this.onDragDown);
+        this._map.on('touchstart', this.move);
+        this._map.on('touchstart', this.onDragDown);
 
-        this.map.on('mousedown', this.onDragDown);
-        this.map.on('mousemove', this.move);
-        this.map.on('click', this.onClick);
+        this._map.on('mousedown', this.onDragDown);
+        this._map.on('mousemove', this.move);
+        this._map.on('click', this.onClick);
       } else {
-        this.map.off('touchstart', this.move);
-        this.map.off('touchstart', this.onDragDown);
+        this._map.off('touchstart', this.move);
+        this._map.off('touchstart', this.onDragDown);
 
-        this.map.off('mousedown', this.onDragDown);
-        this.map.off('mousemove', this.move);
-        this.map.off('click', this.onClick);
+        this._map.off('mousedown', this.onDragDown);
+        this._map.off('mousemove', this.move);
+        this._map.off('click', this.onClick);
       }
 
       return this;

--- a/dist/mapbox-gl-directions.js
+++ b/dist/mapbox-gl-directions.js
@@ -1,9 +1,5 @@
-(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.mapboxDirections = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 'use strict';
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
 
 var _directions = require('./src/directions');
 
@@ -13,6 +9,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 if (window.mapboxgl) {
   mapboxgl.Directions = _directions2.default;
+} else if (typeof module !== 'undefined') {
+  module.exports = _directions2.default;
 } /**
    * A directions component using Mapbox Directions APi
    * @class mapboxgl.Directions
@@ -38,7 +36,6 @@ if (window.mapboxgl) {
    * map.addControl(directions);
    * @return {Directions} `this`
    */
-exports.default = _directions2.default;
 
 },{"./src/directions":36}],2:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
@@ -7456,4 +7453,5 @@ var format = {
 
 exports.default = { format: format, coordinateMatch: coordinateMatch, createPoint: createPoint, validCoords: validCoords, wrap: wrap };
 
-},{}]},{},[1]);
+},{}]},{},[1])(1)
+});

--- a/dist/mapbox-gl-directions.js
+++ b/dist/mapbox-gl-directions.js
@@ -6798,7 +6798,9 @@ var Directions = function () {
           });
         }
 
-        if (_this3._map.style) _this3._map.getSource('directions').setData(geojson);
+        if (_this3._map.style && _this3._map.getSource('directions')) {
+          _this3._map.getSource('directions').setData(geojson);
+        }
       });
     }
   }, {

--- a/dist/mapbox-gl-directions.js
+++ b/dist/mapbox-gl-directions.js
@@ -6680,7 +6680,7 @@ var Directions = function () {
       if (controls.instructions) this.container.appendChild(directionsEl);
 
       this.subscribedActions();
-      this._map.on('style.load', function () {
+      if (this._map.loaded()) this.mapState();else this._map.on('load', function () {
         return _this.mapState();
       });
     }
@@ -6713,12 +6713,13 @@ var Directions = function () {
 
       this.actions.eventEmit('profile', { profile: profile });
 
-      var geojson = new mapboxgl.GeoJSONSource({
+      var geojson = {
+        type: 'geojson',
         data: {
           type: 'FeatureCollection',
           features: []
         }
-      });
+      };
 
       // Add and set data theme layer/style
       this._map.addSource('directions', geojson);

--- a/dist/mapbox-gl-directions.js
+++ b/dist/mapbox-gl-directions.js
@@ -1,6 +1,10 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 'use strict';
 
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
 var _directions = require('./src/directions');
 
 var _directions2 = _interopRequireDefault(_directions);
@@ -9,8 +13,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 if (window.mapboxgl) {
   mapboxgl.Directions = _directions2.default;
-} else if (typeof module !== 'undefined') {
-  module.exports = _directions2.default;
 } /**
    * A directions component using Mapbox Directions APi
    * @class mapboxgl.Directions
@@ -36,6 +38,7 @@ if (window.mapboxgl) {
    * map.addControl(directions);
    * @return {Directions} `this`
    */
+exports.default = _directions2.default;
 
 },{"./src/directions":36}],2:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.

--- a/example/index.html
+++ b/example/index.html
@@ -3,9 +3,8 @@
   <head>
     <title></title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.mapbox.com/mapbox-gl-js/v0.20.0/mapbox-gl.js'></script>
-    <link href='https://api.mapbox.com/mapbox-gl-js/v0.20.0/mapbox-gl.css' rel='stylesheet' />
     <link href='../dist/mapbox-gl-directions.css' rel='stylesheet' />
+    <link href='https://api.mapbox.com/mapbox-gl-js/v0.20.0/mapbox-gl.css' rel='stylesheet' />
     <style>
       body { margin:0; padding:0; }
       .map {
@@ -20,6 +19,7 @@
   <body>
     <div id='map' class='map'></div>
     <div id='directions'></div>
+    <script src='https://api.mapbox.com/mapbox-gl-js/v0.20.0/mapbox-gl.js'></script>
     <script src='bundle.js'></script>
   </body>
 </html>

--- a/example/index.js
+++ b/example/index.js
@@ -1,7 +1,8 @@
 'use strict';
 /* global mapboxgl */
 
-require('../index');
+var Directions = require('../index');
+
 mapboxgl.accessToken = window.localStorage.getItem('MapboxAccessToken');
 
 var map = new mapboxgl.Map({

--- a/index.js
+++ b/index.js
@@ -27,6 +27,6 @@ import Directions from './src/directions';
 
 if (window.mapboxgl) {
   mapboxgl.Directions = Directions;
+} else if (typeof module !== 'undefined') {
+  module.exports = Directions;
 }
-
-export default Directions;

--- a/index.js
+++ b/index.js
@@ -27,6 +27,6 @@ import Directions from './src/directions';
 
 if (window.mapboxgl) {
   mapboxgl.Directions = Directions;
-} else if (typeof module !== 'undefined') {
-  module.exports = Directions;
 }
+
+export default Directions;

--- a/package.json
+++ b/package.json
@@ -55,10 +55,11 @@
     "lodash.debounce": "^4.0.6",
     "lodash.isequal": "^4.2.0",
     "lodash.template": "^4.2.5",
-    "mapbox-gl-geocoder": "^1.3.0",
     "polyline": "^0.2.0",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",
-    "turf-extent": "^1.0.4"
+    "suggestions": "1.3.0",
+    "turf-extent": "^1.0.4",
+    "xtend": "4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "start": "NODE_ENV=development budo example/index.js:example/bundle.js --live",
-    "build": "NODE_ENV=production browserify index.js > dist/mapbox-gl-directions.js",
+    "build": "NODE_ENV=production browserify -s mapboxDirections index.js > dist/mapbox-gl-directions.js",
     "test": "NODE_ENV=test npm run lint && browserify test/index.js | smokestack -b firefox | tap-status",
     "docs": "documentation build --format=md > API.md",
     "lint": "eslint --no-eslintrc -c .eslintrc index.js src"
@@ -45,11 +45,15 @@
     "budo": "^8.3.0",
     "documentation": "^4.0.0-beta5",
     "eslint": "^2.13.1",
+    "json-loader": "0.5.4",
     "lodash.once": "^4.0.0",
     "mapbox-gl": "^0.20.1",
     "smokestack": "^3.3.1",
     "tap-status": "^1.0.1",
-    "tape": "^4.6.0"
+    "tape": "^4.6.0",
+    "transform-loader": "0.2.3",
+    "webpack": "1.13.1",
+    "webworkify-webpack": "1.1.7"
   },
   "dependencies": {
     "lodash.debounce": "^4.0.6",

--- a/src/controls/geocoder.js
+++ b/src/controls/geocoder.js
@@ -1,0 +1,313 @@
+'use strict';
+
+var Typeahead = require('suggestions');
+var debounce = require('lodash.debounce');
+var extend = require('xtend');
+var EventEmitter = require('events').EventEmitter;
+
+// Mapbox Geocoder version
+var API = 'https://api.mapbox.com/geocoding/v5/mapbox.places/';
+
+/**
+ * A geocoder component using Mapbox Geocoding API
+ * @class mapboxgl.Geocoder
+ *
+ * @param {Object} options
+ * @param {String} [options.position="top-right"] A string indicating the control's position on the map. Options are `top-right`, `top-left`, `bottom-right`, `bottom-left`
+ * @param {String} [options.accessToken=null] Required unless `mapboxgl.accessToken` is set globally
+ * @param {string|element} options.container The HTML element to append the Geocoder input to. if container is not specified, `map.getcontainer()` is used.
+ * @param {Array<number>} options.proximity If set, search results closer to these coordinates will be given higher priority.
+ * @param {Array<number>} options.bbox Limit results to a given bounding box provided as `[minX, minY, maxX, maxY]`.
+ * @param {Number} [options.zoom=16] On geocoded result what zoom level should the map animate to.
+ * @param {Boolean} [options.flyTo=true] If false, animating the map to a selected result is disabled.
+ * @param {String} [options.placeholder="Search"] Override the default placeholder attribute value.
+ * @param {string} options.types a comma seperated list of types that filter results to match those specified. See https://www.mapbox.com/developers/api/geocoding/#filter-type for available types.
+ * @param {string} options.country a comma seperated list of country codes to limit results to specified country or countries.
+ * @example
+ * var geocoder = new mapboxgl.Geocoder();
+ * map.addControl(geocoder);
+ * @return {Geocoder} `this`
+ */
+function Geocoder(options) {
+  this._ev = new EventEmitter();
+  this.options = extend({}, this.options, options);
+}
+
+Geocoder.prototype = {
+
+  options: {
+    position: 'top-left',
+    placeholder: 'Search',
+    zoom: 16,
+    flyTo: true
+  },
+
+  addTo: function (map) {
+      this._map = map;
+      var container = this._container = this.onAdd(map);
+      if (this.options && this.options.position) {
+          var pos = this.options.position;
+          var corner = map._controlCorners[pos];
+          container.className += ' mapboxgl-ctrl';
+          if (pos.indexOf('bottom') !== -1) {
+              corner.insertBefore(container, corner.firstChild);
+          } else {
+              corner.appendChild(container);
+          }
+      }
+
+      return this;
+  },
+
+  onAdd: function(map) {
+    this.request = new XMLHttpRequest();
+
+    this.container = this.options.container ?
+      typeof this.options.container === 'string' ?
+      document.getElementById(this.options.container) :
+      this.options.container :
+      map.getContainer();
+
+    // Template
+    var el = document.createElement('div');
+    el.className = 'mapboxgl-ctrl-geocoder';
+
+    var icon = document.createElement('span');
+    icon.className = 'geocoder-icon geocoder-icon-search';
+
+    var input = this._inputEl = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = this.options.placeholder;
+
+    input.addEventListener('keydown', debounce(function(e) {
+      if (!e.target.value) return this._clearEl.classList.remove('active');
+
+      // TAB, ESC, LEFT, RIGHT, ENTER, UP, DOWN
+      if (e.metaKey || [9, 27, 37, 39, 13, 38, 40].indexOf(e.keyCode) !== -1) return;
+      this._queryFromInput(e.target.value);
+    }.bind(this)), 200);
+
+    input.addEventListener('change', function(e) {
+      if (e.target.value) this._clearEl.classList.add('active');
+
+      var selected = this._typeahead.selected;
+      if (selected) {
+        if (this.options.flyTo) {
+          if (selected.bbox && selected.context && selected.context.length <= 3 ||
+              selected.bbox && !selected.context) {
+            var bbox = selected.bbox;
+            map.fitBounds([[bbox[0], bbox[1]],[bbox[2], bbox[3]]]);
+          } else {
+            map.flyTo({
+              center: selected.center,
+              zoom: this.options.zoom
+            });
+          }
+        }
+        this._input = selected;
+        this.fire('result', { result: selected });
+      }
+    }.bind(this));
+
+    var actions = document.createElement('div');
+    actions.classList.add('geocoder-pin-right');
+
+    var clear = this._clearEl = document.createElement('button');
+    clear.className = 'geocoder-icon geocoder-icon-close';
+    clear.addEventListener('click', this._clear.bind(this));
+
+    var loading = this._loadingEl = document.createElement('span');
+    loading.className = 'geocoder-icon geocoder-icon-loading';
+
+    actions.appendChild(clear);
+    actions.appendChild(loading);
+
+    el.appendChild(icon);
+    el.appendChild(input);
+    el.appendChild(actions);
+
+    this.container.appendChild(el);
+
+    // Override the control being added to control containers
+    if (this.options.container) this.options.position = false;
+
+    this._typeahead = new Typeahead(input, [], { filter: false });
+    this._typeahead.getItemValue = function(item) { return item.place_name; };
+
+    return el;
+  },
+
+  _geocode: function(q, callback) {
+    this._loadingEl.classList.add('active');
+    this.fire('loading');
+
+    var options = [];
+    if (this.options.proximity) options.push('proximity=' + this.options.proximity.join());
+    if (this.options.bbox) options.push('bbox=' + this.options.bbox.join());
+    if (this.options.country) options.push('country=' + this.options.country);
+    if (this.options.types) options.push('types=' + this.options.types);
+
+    var accessToken = this.options.accessToken ? this.options.accessToken : mapboxgl.accessToken;
+    options.push('access_token=' + accessToken);
+
+    this.request.abort();
+    this.request.open('GET', API + encodeURIComponent(q.trim()) + '.json?' + options.join('&'), true);
+    this.request.onload = function() {
+      this._loadingEl.classList.remove('active');
+      if (this.request.status >= 200 && this.request.status < 400) {
+        var data = JSON.parse(this.request.responseText);
+        if (data.features.length) {
+          this._clearEl.classList.add('active');
+        } else {
+          this._clearEl.classList.remove('active');
+          this._typeahead.selected = null;
+        }
+
+        this.fire('results', { results: data.features });
+        this._typeahead.update(data.features);
+        return callback(data.features);
+      } else {
+        this.fire('error', { error: JSON.parse(this.request.responseText).message });
+      }
+    }.bind(this);
+
+    this.request.onerror = function() {
+      this._loadingEl.classList.remove('active');
+      this.fire('error', { error: JSON.parse(this.request.responseText).message });
+    }.bind(this);
+
+    this.request.send();
+  },
+
+  _queryFromInput: function(q) {
+    q = q.trim();
+    if (!q) this._clear();
+    if (q.length > 2) {
+      this._geocode(q, function(results) {
+        this._results = results;
+      }.bind(this));
+    }
+  },
+
+  _change: function() {
+    var onChange = document.createEvent('HTMLEvents');
+    onChange.initEvent('change', true, false);
+    this._inputEl.dispatchEvent(onChange);
+  },
+
+  _query: function(input) {
+    if (!input) return;
+    if (typeof input === 'object' && input.length) {
+      input = [
+        mapboxgl.util.wrap(input[0], -180, 180),
+        mapboxgl.util.wrap(input[1], -180, 180)
+      ].join();
+    }
+
+    this._geocode(input, function(results) {
+      if (!results.length) return;
+      var result = results[0];
+      this._results = results;
+      this._typeahead.selected = result;
+      this._inputEl.value = result.place_name;
+      this._change();
+    }.bind(this));
+  },
+
+  _setInput: function(input) {
+    if (!input) return;
+    if (typeof input === 'object' && input.length) {
+      input = [
+        mapboxgl.util.wrap(input[0], -180, 180),
+        mapboxgl.util.wrap(input[1], -180, 180)
+      ].join();
+    }
+
+    // Set input value to passed value and clear everything else.
+    this._inputEl.value = input;
+    this._input = null;
+    this._typeahead.selected = null;
+    this._typeahead.clear();
+    this._change();
+  },
+
+  _clear: function() {
+    this._input = null;
+    this._inputEl.value = '';
+    this._typeahead.selected = null;
+    this._typeahead.clear();
+    this._change();
+    this._inputEl.focus();
+    this._clearEl.classList.remove('active');
+    this.fire('clear');
+  },
+
+  /**
+   * Return the input
+   * @returns {Object} input
+   */
+  getResult: function() {
+    return this._input;
+  },
+
+  /**
+   * Set & query the input
+   * @param {Array|String} query An array of coordinates [lng, lat] or location name as a string.
+   * @returns {Geocoder} this
+   */
+  query: function(query) {
+    this._query(query);
+    return this;
+  },
+
+  /**
+   * Set input
+   * @param {Array|String} value An array of coordinates [lng, lat] or location name as a string. Calling this function just sets the input and does not trigger an API request.
+   * @returns {Geocoder} this
+   */
+  setInput: function(value) {
+    this._setInput(value);
+    return this;
+  },
+
+  /**
+   * Subscribe to events that happen within the plugin.
+   * @param {String} type name of event. Available events and the data passed into their respective event objects are:
+   *
+   * - __clear__ `Emitted when the input is cleared`
+   * - __loading__ `Emitted when the geocoder is looking up a query`
+   * - __results__ `{ results } Fired when the geocoder returns a response`
+   * - __result__ `{ result } Fired when input is set`
+   * - __error__ `{ error } Error as string
+   * @param {Function} fn function that's called when the event is emitted.
+   * @returns {Geocoder} this;
+   */
+  on: function(type, fn) {
+    this._ev.on(type, fn);
+    return this;
+  },
+
+  /**
+   * Fire an event
+   * @param {String} type event name.
+   * @param {Object} data event data to pass to the function subscribed.
+   * @returns {Geocoder} this
+   */
+  fire: function(type, data) {
+    this._ev.emit(type, data);
+    return this;
+  },
+
+  /**
+   * Remove an event
+   * @returns {Geocoder} this
+   * @param {String} type Event name.
+   * @param {Function} fn Function that should unsubscribe to the event emitted.
+   */
+  off: function(type, fn) {
+    this._ev.removeListener(type, fn);
+    return this;
+  }
+};
+
+module.exports = Geocoder;

--- a/src/controls/inputs.js
+++ b/src/controls/inputs.js
@@ -28,7 +28,7 @@ export default class Inputs {
     this.container = el;
     this.actions = actions;
     this.store = store;
-    this.map = map;
+    this._map = map;
 
     this.onAdd();
     this.render();
@@ -47,9 +47,9 @@ export default class Inputs {
         features: [origin, destination]
       });
 
-      this.map.fitBounds([[bb[0], bb[1]], [bb[2], bb[3]]], { padding: 80 });
+      this._map.fitBounds([[bb[0], bb[1]], [bb[2], bb[3]]], { padding: 80 });
     } else {
-      this.map.flyTo({ center: coords });
+      this._map.flyTo({ center: coords });
     }
   }
 
@@ -71,7 +71,7 @@ export default class Inputs {
       container: this.container.querySelector('#mapbox-directions-origin-input')
     }, geocoder));
 
-    this.map.addControl(this.originInput);
+    this._map.addControl(this.originInput);
 
     this.destinationInput = new Geocoder(Object.assign({}, {
       flyTo: false,
@@ -79,7 +79,7 @@ export default class Inputs {
       container: this.container.querySelector('#mapbox-directions-destination-input')
     }, geocoder));
 
-    this.map.addControl(this.destinationInput);
+    this._map.addControl(this.destinationInput);
 
     this.originInput.on('result', (e) => {
       const coords = e.result.center;

--- a/src/controls/inputs.js
+++ b/src/controls/inputs.js
@@ -1,4 +1,4 @@
-import 'mapbox-gl-geocoder';
+import Geocoder from './geocoder';
 import template from 'lodash.template';
 import isEqual from 'lodash.isequal';
 import extent from 'turf-extent';
@@ -65,7 +65,7 @@ export default class Inputs {
 
     const { geocoder } = this.store.getState();
 
-    this.originInput = new mapboxgl.Geocoder(Object.assign({}, {
+    this.originInput = new Geocoder(Object.assign({}, {
       flyTo: false,
       placeholder: 'Choose a starting place',
       container: this.container.querySelector('#mapbox-directions-origin-input')
@@ -73,7 +73,7 @@ export default class Inputs {
 
     this.map.addControl(this.originInput);
 
-    this.destinationInput = new mapboxgl.Geocoder(Object.assign({}, {
+    this.destinationInput = new Geocoder(Object.assign({}, {
       flyTo: false,
       placeholder: 'Choose destination',
       container: this.container.querySelector('#mapbox-directions-destination-input')

--- a/src/controls/instructions.js
+++ b/src/controls/instructions.js
@@ -20,7 +20,7 @@ export default class Instructions {
     this.container = el;
     this.actions = actions;
     this.store = store;
-    this.map = map;
+    this._map = map;
     this.directions = {};
     this.render();
   }
@@ -62,7 +62,7 @@ export default class Instructions {
           });
 
           el.addEventListener('click', () => {
-            this.map.flyTo({
+            this._map.flyTo({
               center: [lng, lat],
               zoom: 16
             });

--- a/src/directions.js
+++ b/src/directions.js
@@ -70,7 +70,8 @@ export default class Directions {
     if (controls.instructions) this.container.appendChild(directionsEl);
 
     this.subscribedActions();
-    this._map.on('style.load', () => this.mapState());
+    if (this._map.loaded()) this.mapState()
+    else this._map.on('load', () => this.mapState());
   }
 
   /**
@@ -90,12 +91,13 @@ export default class Directions {
     // Emit any default or option set config
     this.actions.eventEmit('profile', { profile });
 
-    const geojson = new mapboxgl.GeoJSONSource({
+    const geojson = {
+      type: 'geojson',
       data: {
         type: 'FeatureCollection',
         features: []
       }
-    });
+    };
 
     // Add and set data theme layer/style
     this._map.addSource('directions', geojson);

--- a/src/directions.js
+++ b/src/directions.js
@@ -46,17 +46,17 @@ export default class Directions {
   }
 
   onAdd(map) {
-    this.map = map;
+    this._map = map;
 
     const { container, controls } = store.getState();
 
     this.container = container ? typeof container === 'string' ?
-      document.getElementById(container) : container : this.map.getContainer();
+      document.getElementById(container) : container : this._map.getContainer();
 
     // Add controls to the page
     const inputEl = document.createElement('div');
     inputEl.className = 'directions-control directions-control-inputs';
-    new Inputs(inputEl, store, this.actions, this.map);
+    new Inputs(inputEl, store, this.actions, this._map);
 
     const directionsEl = document.createElement('div');
     directionsEl.className = 'directions-control-directions-container';
@@ -64,13 +64,13 @@ export default class Directions {
     new Instructions(directionsEl, store, {
       hoverMarker: this.actions.hoverMarker,
       setRouteIndex: this.actions.setRouteIndex
-    }, this.map);
+    }, this._map);
 
     if (controls.inputs) this.container.appendChild(inputEl);
     if (controls.instructions) this.container.appendChild(directionsEl);
 
     this.subscribedActions();
-    this.map.on('style.load', () => this.mapState());
+    this._map.on('style.load', () => this.mapState());
   }
 
   /**
@@ -80,7 +80,7 @@ export default class Directions {
    */
   remove() {
       this.container.parentNode.removeChild(this.container);
-      this.map = null;
+      this._map = null;
       return this;
   }
 
@@ -98,20 +98,20 @@ export default class Directions {
     });
 
     // Add and set data theme layer/style
-    this.map.addSource('directions', geojson);
+    this._map.addSource('directions', geojson);
 
     // Add direction specific styles to the map
-    directionsStyle.forEach((style) => this.map.addLayer(style));
+    directionsStyle.forEach((style) => this._map.addLayer(style));
 
-    if (styles && styles.length) styles.forEach((style) => this.map.addLayer(style));
+    if (styles && styles.length) styles.forEach((style) => this._map.addLayer(style));
 
     if (interactive) {
-      this.map.on('mousedown', this.onDragDown);
-      this.map.on('mousemove', this.move);
-      this.map.on('click', this.onClick);
+      this._map.on('mousedown', this.onDragDown);
+      this._map.on('mousemove', this.move);
+      this._map.on('click', this.onClick);
 
-      this.map.on('touchstart', this.move);
-      this.map.on('touchstart', this.onDragDown);
+      this._map.on('touchstart', this.move);
+      this._map.on('touchstart', this.onDragDown);
     }
   }
 
@@ -172,7 +172,7 @@ export default class Directions {
         });
       }
 
-      if (this.map.style) this.map.getSource('directions').setData(geojson);
+      if (this._map.style) this._map.getSource('directions').setData(geojson);
     });
   }
 
@@ -184,7 +184,7 @@ export default class Directions {
       this.actions.setOriginFromCoordinates(coords);
     } else {
 
-      const features = this.map.queryRenderedFeatures(e.point, {
+      const features = this._map.queryRenderedFeatures(e.point, {
         layers: [
           'directions-origin-point',
           'directions-destination-point',
@@ -208,7 +208,7 @@ export default class Directions {
         }
       } else {
         this.actions.setDestinationFromCoordinates(coords);
-        this.map.flyTo({ center: coords });
+        this._map.flyTo({ center: coords });
       }
     }
   }
@@ -216,7 +216,7 @@ export default class Directions {
   _move(e) {
     const { hoverMarker } = store.getState();
 
-    const features = this.map.queryRenderedFeatures(e.point, {
+    const features = this._map.queryRenderedFeatures(e.point, {
       layers: [
         'directions-route-line-alt',
         'directions-route-line',
@@ -226,11 +226,11 @@ export default class Directions {
       ]
     });
 
-    this.map.getCanvas().style.cursor = features.length ? 'pointer' : '';
+    this._map.getCanvas().style.cursor = features.length ? 'pointer' : '';
 
     if (features.length) {
       this.isCursorOverPoint = features[0];
-      this.map.dragPan.disable();
+      this._map.dragPan.disable();
 
       // Add a possible waypoint marker when hovering over the active route line
       features.forEach((feature) => {
@@ -243,20 +243,20 @@ export default class Directions {
 
     } else if (this.isCursorOverPoint) {
       this.isCursorOverPoint = false;
-      this.map.dragPan.enable();
+      this._map.dragPan.enable();
     }
   }
 
   _onDragDown() {
     if (!this.isCursorOverPoint) return;
     this.isDragging = this.isCursorOverPoint;
-    this.map.getCanvas().style.cursor = 'grab';
+    this._map.getCanvas().style.cursor = 'grab';
 
-    this.map.on('mousemove', this.onDragMove);
-    this.map.on('mouseup', this.onDragUp);
+    this._map.on('mousemove', this.onDragMove);
+    this._map.on('mouseup', this.onDragUp);
 
-    this.map.on('touchmove', this.onDragMove);
-    this.map.on('touchend', this.onDragUp);
+    this._map.on('touchmove', this.onDragMove);
+    this._map.on('touchend', this.onDragUp);
   }
 
   _onDragMove(e) {
@@ -297,13 +297,13 @@ export default class Directions {
     }
 
     this.isDragging = false;
-    this.map.getCanvas().style.cursor = '';
+    this._map.getCanvas().style.cursor = '';
 
-    this.map.off('touchmove', this.onDragMove);
-    this.map.off('touchend', this.onDragUp);
+    this._map.off('touchmove', this.onDragMove);
+    this._map.off('touchend', this.onDragUp);
 
-    this.map.off('mousemove', this.onDragMove);
-    this.map.off('mouseup', this.onDragUp);
+    this._map.off('mousemove', this.onDragMove);
+    this._map.off('mouseup', this.onDragUp);
   }
 
   // API Methods
@@ -316,19 +316,19 @@ export default class Directions {
    */
   interactive(state) {
     if (state) {
-      this.map.on('touchstart', this.move);
-      this.map.on('touchstart', this.onDragDown);
+      this._map.on('touchstart', this.move);
+      this._map.on('touchstart', this.onDragDown);
 
-      this.map.on('mousedown', this.onDragDown);
-      this.map.on('mousemove', this.move);
-      this.map.on('click', this.onClick);
+      this._map.on('mousedown', this.onDragDown);
+      this._map.on('mousemove', this.move);
+      this._map.on('click', this.onClick);
     } else {
-      this.map.off('touchstart', this.move);
-      this.map.off('touchstart', this.onDragDown);
+      this._map.off('touchstart', this.move);
+      this._map.off('touchstart', this.onDragDown);
 
-      this.map.off('mousedown', this.onDragDown);
-      this.map.off('mousemove', this.move);
-      this.map.off('click', this.onClick);
+      this._map.off('mousedown', this.onDragDown);
+      this._map.off('mousemove', this.move);
+      this._map.off('click', this.onClick);
     }
 
     return this;

--- a/src/directions.js
+++ b/src/directions.js
@@ -172,7 +172,9 @@ export default class Directions {
         });
       }
 
-      if (this._map.style) this._map.getSource('directions').setData(geojson);
+      if (this._map.style && this._map.getSource('directions')) {
+        this._map.getSource('directions').setData(geojson);
+      }
     });
   }
 

--- a/src/directions.js
+++ b/src/directions.js
@@ -1,5 +1,3 @@
-if (!mapboxgl) throw new Error('include mapboxgl before mapbox-gl-directions.js');
-
 import { createStore, applyMiddleware, bindActionCreators } from 'redux';
 import thunk from 'redux-thunk';
 import { decode } from 'polyline';
@@ -17,10 +15,9 @@ import directionsStyle from './directions_style';
 import Inputs from './controls/inputs';
 import Instructions from './controls/instructions';
 
-export default class Directions extends mapboxgl.Control {
+export default class Directions {
 
   constructor(options) {
-    super();
     this.actions = bindActionCreators(actions, store.dispatch);
     this.actions.setOptions(options || {});
 
@@ -29,6 +26,23 @@ export default class Directions extends mapboxgl.Control {
     this.onDragUp = this._onDragUp.bind(this);
     this.move = this._move.bind(this);
     this.onClick = this._onClick.bind(this);
+  }
+
+  addTo(map) {
+      this._map = map;
+      var container = this._container = this.onAdd(map);
+      if (this.options && this.options.position) {
+          var pos = this.options.position;
+          var corner = map._controlCorners[pos];
+          container.className += ' mapboxgl-ctrl';
+          if (pos.indexOf('bottom') !== -1) {
+              corner.insertBefore(container, corner.firstChild);
+          } else {
+              corner.appendChild(container);
+          }
+      }
+
+      return this;
   }
 
   onAdd(map) {
@@ -57,6 +71,17 @@ export default class Directions extends mapboxgl.Control {
 
     this.subscribedActions();
     this.map.on('style.load', () => this.mapState());
+  }
+
+  /**
+   * Removes the control from the map it has been added to.
+   *
+   * @returns {Control} `this`
+   */
+  remove() {
+      this.container.parentNode.removeChild(this.container);
+      this.map = null;
+      return this;
   }
 
   mapState() {


### PR DESCRIPTION
* Removes dependency on mapboxgl.Directions. Vendors that library. This is so that I can fix bugs in it without a new release, and so that the two modules can share modules and avoid build systems messups.
* Removes require-time dependency on mapboxgl. This is not a guarantee with webpack and other systems, and the previous check was broken ( #84 ) in both modules ( #53 )
* That's it, trying to make this the smallest possible change required to make mapbox-gl-directions friendly with webpack async loading