### PR TITLE
background image center

### DIFF
--- a/src/mapbox-gl-directions.css
+++ b/src/mapbox-gl-directions.css
@@ -204,6 +204,11 @@
   line-height:38px;
   border-radius:0 0 0 3px;
   }
+  .mapbox-form-label.directions-icon {
+    background-position: center;
+    width: 40px;
+    height: 40px;
+    }
   .mapbox-directions-origin .mapbox-form-label {
     background-color:#3bb2d0;
     border-radius:3px 0 0 0;


### PR DESCRIPTION
Fixes a case where icons were not aligning due to different global `line-height` properties. This updates the icons within the depart/arrival space to fit the width of the label and position themselves in the exact center, no matter what.

Issue appeared in #98 