### PR TITLE
deep assign objects, hide instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.3
+
+- [bug] re-enable hiding instructions panel [#101](https://github.com/mapbox/mapbox-gl-directions/issues/101)
+
 ## 3.0.2
 
 - [bug] Fixing a fix for `3.0.1`. Missed a single space.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "webworkify-webpack": "1.1.7"
   },
   "dependencies": {
+    "deep-assign": "^2.0.0",
     "lodash.debounce": "^4.0.6",
     "lodash.isequal": "^4.2.0",
     "lodash.template": "^4.2.5",

--- a/src/directions.js
+++ b/src/directions.js
@@ -43,7 +43,7 @@ export default class MapboxDirections {
     new Inputs(inputEl, store, this.actions, this._map);
 
     const directionsEl = document.createElement('div');
-    directionsEl.className = 'directions-control-directions-container';
+    directionsEl.className = 'directions-control directions-control-instructions';
 
     new Instructions(directionsEl, store, {
       hoverMarker: this.actions.hoverMarker,
@@ -51,7 +51,7 @@ export default class MapboxDirections {
     }, this._map);
 
     if (controls.inputs) el.appendChild(inputEl);
-    el.appendChild(directionsEl);
+    if (controls.instructions) el.appendChild(directionsEl);
 
     this.subscribedActions();
     if (this._map.loaded()) this.mapState()

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,5 @@
 import * as types from '../constants/action_types.js';
+import deepAssign from 'deep-assign';
 
 const initialState = {
   // Options set on initialization
@@ -42,7 +43,7 @@ const initialState = {
 function data(state = initialState, action) {
   switch (action.type) {
   case types.SET_OPTIONS:
-    return Object.assign({}, state, action.options);
+    return deepAssign({}, state, action.options);
 
   case types.DIRECTIONS_PROFILE:
     return Object.assign({}, state, {


### PR DESCRIPTION
Adds an `if` statement to hide the instructions panel based on options: #101 
Introduces node deep-assign to start resolving #103 

cc @rolandoldengarm @tmcw 