### PR TITLE
bring back the constructor options

### DIFF
--- a/API.md
+++ b/API.md
@@ -4,16 +4,31 @@ The Directions control
 
 **Parameters**
 
--   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** no currently accepted options
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+    -   `options.styles` **\[[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)]** Override default layer properties of the [directions source](https://github.com/mapbox/mapbox-gl-directions/blob/master/src/directions_style.js). Documentation for each property are specified in the [Mapbox GL Style Reference](https://www.mapbox.com/mapbox-gl-style-spec/).
+    -   `options.accessToken` **\[[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** Required unless `mapboxgl.accessToken` is set globally (optional, default `null`)
+    -   `options.interactive` **\[[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** Enable/Disable mouse or touch interactivity from the plugin (optional, default `true`)
+    -   `options.profile` **\[[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** Routing profile to use. Options: `driving`, `walking`, `cycling` (optional, default `"driving"`)
+    -   `options.unit` **\[[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** Measurement system to be used in navigation instructions. Options: `imperial`, `metric` (optional, default `"imperial"`)
+    -   `options.geocoder` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Pass options available to mapbox-gl-geocoder as [documented here](https://github.com/mapbox/mapbox-gl-geocoder/blob/master/API.md#mapboxglgeocoder).
+    -   `options.controls` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** 
+        -   `options.controls.inputs` **\[[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** Hide or display the inputs control. (optional, default `true`)
+        -   `options.controls.instructions` **\[[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** Hide or display the instructions control. (optional, default `true`)
 
 **Examples**
 
 ```javascript
+var MapboxDirections = require('../src/index');
 var directions = new MapboxDirections({
-  accessToken: mapboxgl.accessToken
+  accessToken: 'YOUR-MAPBOX-ACCESS-TOKEN',
+  unit: 'metric',
+  profile: 'cycling'
 });
-map.addControl(directions, 'top-left');
+// add to your mapboxgl map
+map.addControl(directions);
 ```
+
+Returns **[MapboxDirections](#mapboxdirections)** `this`
 
 ## onRemove
 

--- a/src/directions.js
+++ b/src/directions.js
@@ -18,12 +18,28 @@ import Instructions from './controls/instructions';
 /**
  * The Directions control
  * @class MapboxDirections
- * @param {Object} options no currently accepted options
+ *
+ * @param {Object} options
+ * @param {Array} [options.styles] Override default layer properties of the [directions source](https://github.com/mapbox/mapbox-gl-directions/blob/master/src/directions_style.js). Documentation for each property are specified in the [Mapbox GL Style Reference](https://www.mapbox.com/mapbox-gl-style-spec/).
+ * @param {String} [options.accessToken=null] Required unless `mapboxgl.accessToken` is set globally
+ * @param {Boolean} [options.interactive=true] Enable/Disable mouse or touch interactivity from the plugin
+ * @param {String} [options.profile="driving"] Routing profile to use. Options: `driving`, `walking`, `cycling`
+ * @param {String} [options.unit="imperial"] Measurement system to be used in navigation instructions. Options: `imperial`, `metric`
+ * @param {Object} [options.geocoder] Pass options available to mapbox-gl-geocoder as [documented here](https://github.com/mapbox/mapbox-gl-geocoder/blob/master/API.md#mapboxglgeocoder).
+ * @param {Object} [options.controls]
+ * @param {Boolean} [options.controls.inputs=true] Hide or display the inputs control.
+ * @param {Boolean} [options.controls.instructions=true] Hide or display the instructions control.
  * @example
+ * var MapboxDirections = require('../src/index');
  * var directions = new MapboxDirections({
- *   accessToken: mapboxgl.accessToken
+ *   accessToken: 'YOUR-MAPBOX-ACCESS-TOKEN',
+ *   unit: 'metric',
+ *   profile: 'cycling'
  * });
- * map.addControl(directions, 'top-left');
+ * // add to your mapboxgl map
+ * map.addControl(directions);
+ *
+ * @return {MapboxDirections} `this`
  */
 export default class MapboxDirections {
 
@@ -448,7 +464,7 @@ export default class MapboxDirections {
    * Removes all routes and waypoints from the map.
    *
    * @returns {MapboxDirections} this;
-   */ 
+   */
   removeRoutes() {
     this.actions.clearOrigin();
     this.actions.clearDestination();

--- a/src/index.js
+++ b/src/index.js
@@ -1,29 +1,3 @@
-/**
- * A directions component using Mapbox Directions API
- * @class MapboxDirections
- *
- * @param {Object} options
- * @param {Array} [options.styles] Override default layer properties of the [directions source](https://github.com/mapbox/mapbox-gl-directions/blob/master/src/directions_style.js). Documentation for each property are specified in the [Mapbox GL Style Reference](https://www.mapbox.com/mapbox-gl-style-spec/).
- * @param {String} [options.accessToken=null] Required unless `mapboxgl.accessToken` is set globally
- * @param {Boolean} [options.interactive=true] Enable/Disable mouse or touch interactivity from the plugin
- * @param {String} [options.profile="driving"] Routing profile to use. Options: `driving`, `walking`, `cycling`
- * @param {String} [options.unit="imperial"] Measurement system to be used in navigation instructions. Options: `imperial`, `metric`
- * @param {Object} [options.geocoder] Pass options available to mapbox-gl-geocoder as [documented here](https://github.com/mapbox/mapbox-gl-geocoder/blob/master/API.md#mapboxglgeocoder).
- * @param {Object} [options.controls]
- * @param {Boolean} [options.controls.inputs=true] Hide or display the inputs control.
- * @param {Boolean} [options.controls.instructions=true] Hide or display the instructions control.
- * @example
- * var MapboxDirections = require('../src/index');
- * var directions = new MapboxDirections({
- *   accessToken: 'YOUR-MAPBOX-ACCESS-TOKEN',
- *   unit: 'metric',
- *   profile: 'cycling'
- * });
- * // add to your mapboxgl map
- * map.addControl(directions);
- * 
- * @return {MapboxDirections} `this`
- */
 import MapboxDirections from './directions';
 
 module.exports = MapboxDirections;


### PR DESCRIPTION
Constructor options were in `index.js`, but they should have been in `direction.js` with the real constructor. Fixes discussion in #107 

cc @tmcw 