### PR TITLE
Unsubscribe from store on remove

### DIFF
--- a/src/directions.js
+++ b/src/directions.js
@@ -100,6 +100,10 @@ export default class MapboxDirections {
     map.off('touchstart', this.onDragDown);
     map.off('touchstart', this.move);
     map.off('click', this.onClick);
+    if (this.storeUnsubscribe) {
+      this.storeUnsubscribe();
+      delete this.storeUnsubscribe;
+    }
     this._map = null;
     return this;
   }
@@ -137,7 +141,7 @@ export default class MapboxDirections {
   }
 
   subscribedActions() {
-    store.subscribe(() => {
+    this.storeUnsubscribe = store.subscribe(() => {
       const {
         origin,
         destination,


### PR DESCRIPTION
Right now, if you create an instance, then remove it, then add a new instance, it breaks since they share the same store. The old subscription still runs but `this.map` is undefined and so `this.map.styles` on `subscribedActions` breaks.

This fix is kind-of a hack. The question is: Should each instance have its own store? If so, then we should change any reference to `store` to `this.store` and create a new store in the constructor. 

I really do think that creating a store-per-instance might be the right approach, but even then we'd want to unsubscribe ourselves from our own store to remove a reference and possible memory leak so this PR would still be beneficial. In the short term this will fix the bug and not change anything about the "shared store" that is used right now.