### PR TITLE
Add deployment script which publishes to s3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,4 +29,3 @@ Lastly, run the test command from the console:
 - `git tag -a vX.X.X -m 'vX.X.X'`
 - `git push --tags`
 - `npm publish`
-- Deploy packaged plugin in [mapbox-gl-js/plugins](https://github.com/mapbox/mapbox-gl-js/tree/mb-pages/plugins)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,9 @@ Lastly, run the test command from the console:
 
 ### Deploying
 
-- `npm run build && npm run docs`
-- Update the version key in [package.json](https://github.com/mapbox/mapbox-gl-directions/blob/master/package.json#L3)
-- Update [CHANGELOG.md](https://github.com/mapbox/mapbox-gl-directions/blob/master/CHANGELOG.md)
-- Commit and push
-- `git tag -a vX.X.X -m 'vX.X.X'`
-- `git push --tags`
+- `npm test`
+- Update `[CHANGELOG.md](https://github.com/mapbox/mapbox-gl-directions/blob/master/CHANGELOG.md)`
+- `git commit -am "Update changelog"`
+- `npm version {major|minor|patch}`
+- `git push --follow-tags`
 - `npm publish`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,4 @@ Lastly, run the test command from the console:
 - `npm version {major|minor|patch}`
 - `git push --follow-tags`
 - `npm publish`
+- update version number on [GL JS example page](https://github.com/mapbox/mapbox-gl-js/blob/mb-pages/docs/_posts/examples/3400-01-11-mapbox-gl-directions.html)

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,11 @@
 test:
   override:
     - npm run lint
+deployment:
+  release:
+    tag: /v[0-9]+\.[0-9]+\.[0-9]+(\-dev)?/
+    commands:
+      - aws s3 cp --recursive --acl public-read dist s3://mapbox-gl-js/plugins/mapbox-gl-directions/$CIRCLE_TAG
 machine:
   node:
     version: 4

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "start": "NODE_ENV=development budo example/index.js:example/bundle.js --live",
-    "build": "NODE_ENV=production mkdir -p dist && browserify -s MapboxDirections src/index.js > dist/mapbox-gl-directions.js && cp src/mapbox-gl-directions.css dist/ && cp -r src/icons/ dist/",
+    "build": "NODE_ENV=production mkdir -p dist && browserify -s MapboxDirections src/index.js > dist/mapbox-gl-directions.js && cp src/mapbox-gl-directions.css dist",
     "test": "NODE_ENV=test npm run lint && browserify test/index.js | smokestack -b firefox | tap-status",
     "docs": "documentation build src/directions.js --shallow --format=md > API.md",
     "lint": "eslint --no-eslintrc -c .eslintrc src"


### PR DESCRIPTION
This PR adds a deployment script which publishes `mapbox-gl-directions` to s3 via CircleCI whenever a release tag is pushed to GitHub. This frees us from having to do deployment manually within the GL JS repository.

# Open Questions

 - should we also deploy to our `cn-north-1` bucket?