### PR TITLE
Mention other GL-compatible directions libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Mapbox GL Directions
 ---
 
-A full featured directions plugin for [mapbox-gl-js](https://github.com/mapbox/mapbox-gl-js) using the [Mapbox Directions API](https://www.mapbox.com/developers/api/directions/).
+A full featured directions plugin for [Mapbox GL JS](https://github.com/mapbox/mapbox-gl-js) using the [Mapbox Directions API](https://www.mapbox.com/directions/). Quickly add UI to display driving, cycling, or walking directions on the map. The Mapbox Directions API is powered by the [OSRM](http://project-osrm.org/) routing engine and open data from the [OpenStreetMap](https://www.openstreetmap.org/) project.
+
+For directions functionality in native mobile and desktop applications, see [Mapbox Android Services](https://github.com/mapbox/mapbox-java/), [MapboxDirections.swift](https://github.com/mapbox/MapboxDirections.swift/), and [MapboxNavigation.swift](https://github.com/mapbox/MapboxNavigation.swift/).
 
 ### Usage
 


### PR DESCRIPTION
Described this plugin with language similar to MapboxDirections.swift’s readme description. Linked to GL-compatible directions libraries for other platforms, since “Mapbox GL Directions” could be misinterpreted to mean directions for any Mapbox GL library.

/cc @captainbarbosa @mollymerp @friedbunny