### PR TITLE
Babelify dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "babel-core": "^6.9.1",
     "babel-eslint": "^6.0.5",
     "babel-plugin-object-assign": "^1.2.1",
-    "babel-preset-es2015": "^6.9.0",
     "brfs": "^1.4.1",
     "browserify": "^13.0.1",
     "budo": "^8.3.0",
@@ -60,6 +59,7 @@
   "dependencies": {
     "babelify": "^7.3.0",
     "babel-plugin-transform-inline-environment-variables": "^6.8.0",
+    "babel-preset-es2015": "^6.9.0",
     "deep-assign": "^2.0.0",
     "lodash.debounce": "^4.0.6",
     "lodash.isequal": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "babel-plugin-object-assign": "^1.2.1",
     "babel-plugin-transform-inline-environment-variables": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
-    "babelify": "^7.3.0",
     "brfs": "^1.4.1",
     "browserify": "^13.0.1",
     "budo": "^8.3.0",
@@ -60,6 +59,7 @@
     "webworkify-webpack": "1.1.7"
   },
   "dependencies": {
+    "babelify": "^7.3.0",
     "deep-assign": "^2.0.0",
     "lodash.debounce": "^4.0.6",
     "lodash.isequal": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "babel-core": "^6.9.1",
     "babel-eslint": "^6.0.5",
     "babel-plugin-object-assign": "^1.2.1",
-    "babel-plugin-transform-inline-environment-variables": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "brfs": "^1.4.1",
     "browserify": "^13.0.1",
@@ -60,6 +59,7 @@
   },
   "dependencies": {
     "babelify": "^7.3.0",
+    "babel-plugin-transform-inline-environment-variables": "^6.8.0",
     "deep-assign": "^2.0.0",
     "lodash.debounce": "^4.0.6",
     "lodash.isequal": "^4.2.0",


### PR DESCRIPTION
Move these `devDependencies` under `dependencies` was needed in order to `require()` this project from another browserify project.