### PR TITLE
Toggle or disable profile switcher.

### DIFF
--- a/src/controls/inputs.js
+++ b/src/controls/inputs.js
@@ -17,12 +17,13 @@ let tmpl = template(fs.readFileSync(__dirname + '/../templates/inputs.html', 'ut
  */
 export default class Inputs {
   constructor(el, store, actions, map) {
-    const { originQuery, destinationQuery, profile } = store.getState();
+    const { originQuery, destinationQuery, profile, profileSwitcher } = store.getState();
 
     el.innerHTML = tmpl({
       originQuery,
       destinationQuery,
-      profile
+      profile,
+      profileSwitcher
     });
 
     this.container = el;

--- a/src/controls/inputs.js
+++ b/src/controls/inputs.js
@@ -17,13 +17,13 @@ let tmpl = template(fs.readFileSync(__dirname + '/../templates/inputs.html', 'ut
  */
 export default class Inputs {
   constructor(el, store, actions, map) {
-    const { originQuery, destinationQuery, profile, profileSwitcher } = store.getState();
+    const { originQuery, destinationQuery, profile, controls } = store.getState();
 
     el.innerHTML = tmpl({
       originQuery,
       destinationQuery,
       profile,
-      profileSwitcher
+      controls
     });
 
     this.container = el;

--- a/src/directions.js
+++ b/src/directions.js
@@ -24,7 +24,6 @@ import Instructions from './controls/instructions';
  * @param {String} [options.accessToken=null] Required unless `mapboxgl.accessToken` is set globally
  * @param {Boolean} [options.interactive=true] Enable/Disable mouse or touch interactivity from the plugin
  * @param {String} [options.profile="mapbox/driving-traffic"] Routing profile to use. Options: `mapbox/driving-traffic`, `mapbox/driving`, `mapbox/walking`, `mapbox/cycling`
- * @param {Boolean} [options.profileSwitcher=true] Whether to show the default profile switch with options for traffic, driving, walking and cycling.
  * @param {Boolean} [options.alternatives=true] Whether to enable alternatives.
  * @param {String} [options.unit="imperial"] Measurement system to be used in navigation instructions. Options: `imperial`, `metric`
  * @param {Function} [options.compile=null] Provide a custom function for generating instruction, compatible with osrm-text-instructions.
@@ -32,6 +31,7 @@ import Instructions from './controls/instructions';
  * @param {Object} [options.controls]
  * @param {Boolean} [options.controls.inputs=true] Hide or display the inputs control.
  * @param {Boolean} [options.controls.instructions=true] Hide or display the instructions control.
+ * @param {Boolean} [options.controls.profileSwitcher=true] Hide or display the default profile switch with options for traffic, driving, walking and cycling.
  * @example
  * var MapboxDirections = require('../src/index');
  * var directions = new MapboxDirections({

--- a/src/directions.js
+++ b/src/directions.js
@@ -24,6 +24,7 @@ import Instructions from './controls/instructions';
  * @param {String} [options.accessToken=null] Required unless `mapboxgl.accessToken` is set globally
  * @param {Boolean} [options.interactive=true] Enable/Disable mouse or touch interactivity from the plugin
  * @param {String} [options.profile="mapbox/driving-traffic"] Routing profile to use. Options: `mapbox/driving-traffic`, `mapbox/driving`, `mapbox/walking`, `mapbox/cycling`
+ * @param {Boolean} [options.profileSwitcher=true] Whether to show the default profile switch with options for traffic, driving, walking and cycling.
  * @param {Boolean} [options.alternatives=true] Whether to enable alternatives.
  * @param {String} [options.unit="imperial"] Measurement system to be used in navigation instructions. Options: `imperial`, `metric`
  * @param {Function} [options.compile=null] Provide a custom function for generating instruction, compatible with osrm-text-instructions.

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,7 @@ const initialState = {
   // Options set on initialization
   api: 'https://api.mapbox.com/directions/v5/',
   profile: 'mapbox/driving-traffic',
+  profileSwitcher: true,
   alternatives: false,
   unit: 'imperial',
   compile: null,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,7 +5,6 @@ const initialState = {
   // Options set on initialization
   api: 'https://api.mapbox.com/directions/v5/',
   profile: 'mapbox/driving-traffic',
-  profileSwitcher: true,
   alternatives: false,
   unit: 'imperial',
   compile: null,
@@ -14,6 +13,7 @@ const initialState = {
 
   // UI controls
   controls: {
+    profileSwitcher: true,
     inputs: true,
     instructions: true
   },

--- a/src/templates/inputs.html
+++ b/src/templates/inputs.html
@@ -20,6 +20,7 @@
     </div>
   </div>
 
+  <% if (profileSwitcher) { %>
   <div class='mapbox-directions-profile mapbox-directions-component-keyline mapbox-directions-clearfix'><input
       id='mapbox-directions-profile-driving-traffic'
       type='radio'
@@ -53,4 +54,5 @@
     />
     <label for='mapbox-directions-profile-cycling'>Cycling</label>
   </div>
+  <% } %>
 </div>

--- a/src/templates/inputs.html
+++ b/src/templates/inputs.html
@@ -20,7 +20,7 @@
     </div>
   </div>
 
-  <% if (profileSwitcher) { %>
+  <% if (controls.profileSwitcher) { %>
   <div class='mapbox-directions-profile mapbox-directions-component-keyline mapbox-directions-clearfix'><input
       id='mapbox-directions-profile-driving-traffic'
       type='radio'


### PR DESCRIPTION
This adds the ability to show/hide the profile switcher. Useful alongside https://github.com/mapbox/mapbox-gl-directions/pull/138.