### PR TITLE
Round input floats to original precision if < 5

### DIFF
--- a/src/controls/geocoder.js
+++ b/src/controls/geocoder.js
@@ -178,8 +178,8 @@ Geocoder.prototype = {
     if (!input) return;
     if (typeof input === 'object' && input.length) {
       input = [
-        utils.wrap(input[0]).toFixed(5),
-        utils.wrap(input[1]).toFixed(5)
+        utils.roundWithOriginalPrecision(utils.wrap(input[0]), input[0]),
+        utils.roundWithOriginalPrecision(utils.wrap(input[1]), input[1])
       ].join();
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,6 +16,14 @@ function wrap(n) {
   return (w === -180) ? 180 : w;
 }
 
+function roundWithOriginalPrecision(input, original) {
+  let precision = 0;
+  if (Math.floor(original) !== original) {
+    precision = original.toString().split('.')[1].length;
+  }
+  return input.toFixed(Math.min(precision, 5));
+}
+
 function createPoint(coordinates, properties) {
   return {
     type: 'Feature',
@@ -54,4 +62,4 @@ const format = {
   }
 };
 
-export default { format, coordinateMatch, createPoint, validCoords, wrap };
+export default { format, coordinateMatch, createPoint, validCoords, wrap, roundWithOriginalPrecision };

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,7 @@ require('./test.directions');
 // require('./test.options');
 require('./test.inputs');
 require('./test.instructions');
+require('./test.utils');
 
 // close the smokestack window once tests are complete
 test('shutdown', (t) => {

--- a/test/test.utils.js
+++ b/test/test.utils.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const test = require('tape');
+import utils from '../src/utils';
+
+test('Directions#utils', tt => {
+  tt.test('roundWithOriginalPrecision', (t) => {
+    t.equal(utils.roundWithOriginalPrecision(11.1000000, 11.1), '11.1');
+    t.equal(utils.roundWithOriginalPrecision(11.1000000, 11.1000000000), '11.1');
+    t.equal(utils.roundWithOriginalPrecision(11.1234567, 11.1234567890), '11.12346');
+    t.equal(utils.roundWithOriginalPrecision(11.0000000, 11), '11');
+
+    t.end();
+  });
+
+  tt.end();
+});


### PR DESCRIPTION
Follow-up to https://github.com/mapbox/mapbox-gl-directions/pull/154, but preserves original decimal length if it's less than 5.

Also adds a `utils` test file to test a new method, but it needs more 🍔! Our test suite is 😱 

Fixes https://github.com/mapbox/mapbox-gl-directions/issues/156.