### PR TITLE
fail with a helpful message if no access token is set

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,12 @@ require('../src/index');
 
 mapboxgl.accessToken = process.env.MapboxAccessToken;
 
+if (!mapboxgl.accessToken) {
+  throw new Error('No MapboxAccessToken environment variable set. Please run `export MapboxAccessToken=<your token> && npm test`');
+  window.close();
+  process.exit(0);
+}
+
 // Tests
 require('./test.directions');
 // require('./test.options');


### PR DESCRIPTION
fixes #154 