### PR TITLE
Change package main file to `dist`, alternative `module` for webpack/rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "@mapbox/mapbox-gl-directions",
   "version": "3.1.2",
   "description": "A mapboxgl plugin for the Mapbox Directions API",
-  "main": "./src/index.js",
+  "main": "./dist/mapbox-gl-directions.js",
+  "module": "./src/index.js",
+  "jsnext:main": "./src/index.js",
   "browserify": {
     "transform": [
       "babelify",


### PR DESCRIPTION
I think package.json's `main` field should be built file. (can be used in vanilla js).
Now for webpack/rollup, `module` field is available, so I edited package.json about them.

FYI: [What is the “module” package.json field for?](https://stackoverflow.com/questions/42708484/what-is-the-module-package-json-field-for)