### PR TITLE
Corrected typos in Parameter documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -168,13 +168,14 @@ Subscribe to events that happen within the plugin.
 
 **Parameters**
 
--   `type` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** name of event. Available events and the data passed into their respective event objects are:-   **clear** `{ type: } Type is one of 'origin' or 'destination'`
+-   `type` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** name of event. Available events and the data passed into their respective event objects are:
+    -   **clear** `{ type: } Type is one of 'origin' or 'destination'`
     -   **loading** `{ type: } Type is one of 'origin' or 'destination'`
     -   **profile** `{ profile } Profile is one of 'driving', 'walking', or 'cycling'`
-    -   **origin** `{ feature } Fired when origin is set`
-    -   **destination** `{ feature } Fired when destination is set`
+    -   **origin** `{ origin } Fired when origin is set`
+    -   **destination** `{ destination } Fired when destination is set`
     -   **route** `{ route } Fired when a route is updated`
-    -   **error** \`{ error } Error as string
+    -   **error** `{ error } Error as string`
 -   `fn` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** function that's called when the event is emitted.
 
 Returns **[MapboxDirections](#mapboxdirections)** this;


### PR DESCRIPTION
There were typos in the Parameter documentation and the formatting was off for (clear)