### PR TITLE
Make overview configurable

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,20 +2,20 @@
 
 ### Table of Contents
 
--   [MapboxDirections](#mapboxdirections)
-    -   [onRemove](#onremove)
-    -   [interactive](#interactive)
-    -   [getOrigin](#getorigin)
-    -   [setOrigin](#setorigin)
-    -   [getDestination](#getdestination)
-    -   [setDestination](#setdestination)
-    -   [reverse](#reverse)
-    -   [addWaypoint](#addwaypoint)
-    -   [setWaypoint](#setwaypoint)
-    -   [removeWaypoint](#removewaypoint)
-    -   [getWaypoints](#getwaypoints)
-    -   [removeRoutes](#removeroutes)
-    -   [on](#on)
+- [MapboxDirections](#mapboxdirections)
+  - [onRemove](#onremove)
+  - [interactive](#interactive)
+  - [getOrigin](#getorigin)
+  - [setOrigin](#setorigin)
+  - [getDestination](#getdestination)
+  - [setDestination](#setdestination)
+  - [reverse](#reverse)
+  - [addWaypoint](#addwaypoint)
+  - [setWaypoint](#setwaypoint)
+  - [removeWaypoint](#removewaypoint)
+  - [getWaypoints](#getwaypoints)
+  - [removeRoutes](#removeroutes)
+  - [on](#on)
 
 ## MapboxDirections
 
@@ -23,34 +23,35 @@ The Directions control
 
 **Parameters**
 
--   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-    -   `options.styles` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)?** Override default layer properties of the [directions source](https://github.com/mapbox/mapbox-gl-directions/blob/master/src/directions_style.js). Documentation for each property are specified in the [Mapbox GL Style Reference](https://www.mapbox.com/mapbox-gl-style-spec/).
-    -   `options.accessToken` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Required unless `mapboxgl.accessToken` is set globally (optional, default `null`)
-    -   `options.api` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Override default routing endpoint url (optional, default `"https://api.mapbox.com/directions/v5/"`)
-    -   `options.interactive` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Enable/Disable mouse or touch interactivity from the plugin (optional, default `true`)
-    -   `options.profile` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Routing profile to use. Options: `mapbox/driving-traffic`, `mapbox/driving`, `mapbox/walking`, `mapbox/cycling` (optional, default `"mapbox/driving-traffic"`)
-    -   `options.alternatives` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether to enable alternatives. (optional, default `false`)
-    -   `options.congestion` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether to enable congestion along the route line. (optional, default `false`)
-    -   `options.unit` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Measurement system to be used in navigation instructions. Options: `imperial`, `metric` (optional, default `"imperial"`)
-    -   `options.compile` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** Provide a custom function for generating instruction, compatible with osrm-text-instructions. (optional, default `null`)
-    -   `options.geocoder` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Accepts an object containing the query parameters as [documented here](https://www.mapbox.com/api-documentation/#search-for-places).
-    -   `options.controls` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** 
-        -   `options.controls.inputs` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Hide or display the inputs control. (optional, default `true`)
-        -   `options.controls.instructions` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Hide or display the instructions control. (optional, default `true`)
-        -   `options.controls.profileSwitcher` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Hide or display the default profile switch with options for traffic, driving, walking and cycling. (optional, default `true`)
-    -   `options.zoom` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** If no bbox exists from the geocoder result, the zoom you set here will be used in the flyTo. (optional, default `16`)
-    -   `options.placeholderOrigin` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** If set, this text will appear as the placeholder attribute for the origin input element. (optional, default `"Choose a starting place"`)
-    -   `options.placeholderDestination` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** If set, this text will appear as the placeholder attribute for the destination input element. (optional, default `"Choose destination"`)
-    -   `options.flyTo` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If false, animating the map to a selected result is disabled. (optional, default `true`)
+- `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+  - `options.styles` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)?** Override default layer properties of the [directions source](https://github.com/mapbox/mapbox-gl-directions/blob/master/src/directions_style.js). Documentation for each property are specified in the [Mapbox GL Style Reference](https://www.mapbox.com/mapbox-gl-style-spec/).
+  - `options.accessToken` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Required unless `mapboxgl.accessToken` is set globally (optional, default `null`)
+  - `options.api` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Override default routing endpoint url (optional, default `"https://api.mapbox.com/directions/v5/"`)
+  - `options.interactive` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Enable/Disable mouse or touch interactivity from the plugin (optional, default `true`)
+  - `options.profile` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Routing profile to use. Options: `mapbox/driving-traffic`, `mapbox/driving`, `mapbox/walking`, `mapbox/cycling` (optional, default `"mapbox/driving-traffic"`)
+  - `options.alternatives` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether to enable alternatives. (optional, default `false`)
+  - `options.congestion` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether to enable congestion along the route line. (optional, default `false`)
+  - `options.overview` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The type of returned overview geometry. Can be full (the most detailed geometry available), simplified (default, a simplified version of the full geometry)
+  - `options.unit` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Measurement system to be used in navigation instructions. Options: `imperial`, `metric` (optional, default `"imperial"`)
+  - `options.compile` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** Provide a custom function for generating instruction, compatible with osrm-text-instructions. (optional, default `null`)
+  - `options.geocoder` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Accepts an object containing the query parameters as [documented here](https://www.mapbox.com/api-documentation/#search-for-places).
+  - `options.controls` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?**
+    - `options.controls.inputs` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Hide or display the inputs control. (optional, default `true`)
+    - `options.controls.instructions` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Hide or display the instructions control. (optional, default `true`)
+    - `options.controls.profileSwitcher` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Hide or display the default profile switch with options for traffic, driving, walking and cycling. (optional, default `true`)
+  - `options.zoom` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** If no bbox exists from the geocoder result, the zoom you set here will be used in the flyTo. (optional, default `16`)
+  - `options.placeholderOrigin` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** If set, this text will appear as the placeholder attribute for the origin input element. (optional, default `"Choose a starting place"`)
+  - `options.placeholderDestination` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** If set, this text will appear as the placeholder attribute for the destination input element. (optional, default `"Choose destination"`)
+  - `options.flyTo` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If false, animating the map to a selected result is disabled. (optional, default `true`)
 
 **Examples**
 
 ```javascript
-var MapboxDirections = require('../src/index');
+var MapboxDirections = require("../src/index");
 var directions = new MapboxDirections({
-  accessToken: 'YOUR-MAPBOX-ACCESS-TOKEN',
-  unit: 'metric',
-  profile: 'mapbox/cycling'
+  accessToken: "YOUR-MAPBOX-ACCESS-TOKEN",
+  unit: "metric",
+  profile: "mapbox/cycling"
 });
 // add to your mapboxgl map
 map.addControl(directions);
@@ -65,7 +66,7 @@ which is the recommended method to remove controls.
 
 **Parameters**
 
--   `map`  
+- `map`
 
 Returns **Control** `this`
 
@@ -75,7 +76,7 @@ Turn on or off interactivity
 
 **Parameters**
 
--   `state` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** sets interactivity based on a state of `true` or `false`.
+- `state` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** sets interactivity based on a state of `true` or `false`.
 
 Returns **[MapboxDirections](#mapboxdirections)** this
 
@@ -92,7 +93,7 @@ to have run.
 
 **Parameters**
 
--   `query` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)> | [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** An array of coordinates [lng, lat] or location name as a string.
+- `query` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)> | [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** An array of coordinates [lng, lat] or location name as a string.
 
 Returns **[MapboxDirections](#mapboxdirections)** this
 
@@ -109,7 +110,7 @@ to have run.
 
 **Parameters**
 
--   `query` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)> | [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** An array of coordinates [lng, lat] or location name as a string.
+- `query` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)> | [String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** An array of coordinates [lng, lat] or location name as a string.
 
 Returns **[MapboxDirections](#mapboxdirections)** this
 
@@ -126,8 +127,8 @@ Add a waypoint to the route. _Note:_ calling this method requires the
 
 **Parameters**
 
--   `index` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** position waypoint should be placed in the waypoint array
--   `waypoint` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)> | Point)** can be a GeoJSON Point Feature or [lng, lat] coordinates.
+- `index` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** position waypoint should be placed in the waypoint array
+- `waypoint` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)> | Point)** can be a GeoJSON Point Feature or [lng, lat] coordinates.
 
 Returns **[MapboxDirections](#mapboxdirections)** this;
 
@@ -139,8 +140,8 @@ to have run.
 
 **Parameters**
 
--   `index` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** indexed position of the waypoint to update
--   `waypoint` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)> | Point)** can be a GeoJSON Point Feature or [lng, lat] coordinates.
+- `index` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** indexed position of the waypoint to update
+- `waypoint` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)> | Point)** can be a GeoJSON Point Feature or [lng, lat] coordinates.
 
 Returns **[MapboxDirections](#mapboxdirections)** this;
 
@@ -150,7 +151,7 @@ Remove a waypoint from the route.
 
 **Parameters**
 
--   `index` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** position in the waypoints array.
+- `index` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** position in the waypoints array.
 
 Returns **[MapboxDirections](#mapboxdirections)** this;
 
@@ -172,13 +173,13 @@ Subscribe to events that happen within the plugin.
 
 **Parameters**
 
--   `type` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** name of event. Available events and the data passed into their respective event objects are:-   **clear** `{ type: } Type is one of 'origin' or 'destination'`
-    -   **loading** `{ type: } Type is one of 'origin' or 'destination'`
-    -   **profile** `{ profile } Profile is one of 'driving', 'walking', or 'cycling'`
-    -   **origin** `{ feature } Fired when origin is set`
-    -   **destination** `{ feature } Fired when destination is set`
-    -   **route** `{ route } Fired when a route is updated`
-    -   **error** \`{ error } Error as string
--   `fn` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** function that's called when the event is emitted.
+- `type` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** name of event. Available events and the data passed into their respective event objects are:- **clear** `{ type: } Type is one of 'origin' or 'destination'`
+  - **loading** `{ type: } Type is one of 'origin' or 'destination'`
+  - **profile** `{ profile } Profile is one of 'driving', 'walking', or 'cycling'`
+  - **origin** `{ feature } Fired when origin is set`
+  - **destination** `{ feature } Fired when destination is set`
+  - **route** `{ route } Fired when a route is updated`
+  - **error** \`{ error } Error as string
+- `fn` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** function that's called when the event is emitted.
 
 Returns **[MapboxDirections](#mapboxdirections)** this;

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,28 +1,28 @@
-import * as types from "../constants/action_types";
-import utils from "../utils";
+import * as types from '../constants/action_types';
+import utils from '../utils';
 const request = new XMLHttpRequest();
 
 function originPoint(coordinates) {
   return dispatch => {
     const origin = utils.createPoint(coordinates, {
-      id: "origin",
-      "marker-symbol": "A"
+      id: 'origin',
+      'marker-symbol': 'A'
     });
 
     dispatch({ type: types.ORIGIN, origin });
-    dispatch(eventEmit("origin", { feature: origin }));
+    dispatch(eventEmit('origin', { feature: origin }));
   };
 }
 
 function destinationPoint(coordinates) {
   return dispatch => {
     const destination = utils.createPoint(coordinates, {
-      id: "destination",
-      "marker-symbol": "B"
+      id: 'destination',
+      'marker-symbol': 'B'
     });
 
     dispatch({ type: types.DESTINATION, destination });
-    dispatch(eventEmit("destination", { feature: destination }));
+    dispatch(eventEmit('destination', { feature: destination }));
   };
 }
 
@@ -32,7 +32,7 @@ function setDirections(directions) {
       type: types.DIRECTIONS,
       directions
     });
-    dispatch(eventEmit("route", { route: directions }));
+    dispatch(eventEmit('route', { route: directions }));
   };
 }
 
@@ -69,20 +69,20 @@ function fetchDirections() {
 
     // Request params
     var options = [];
-    options.push("geometries=polyline");
-    if (alternatives) options.push("alternatives=true");
-    if (congestion) options.push("annotations=congestion");
-    options.push("steps=true");
-    if (overview !== "simplified" || overview !== "full") {
-      options.push("overview=simplified");
+    options.push('geometries=polyline');
+    if (alternatives) options.push('alternatives=true');
+    if (congestion) options.push('annotations=congestion');
+    options.push('steps=true');
+    if (overview !== 'simplified' || overview !== 'full') {
+      options.push('overview=simplified');
     } else {
       options.push(`overview=${overview}`);
     }
-    if (accessToken) options.push("access_token=" + accessToken);
+    if (accessToken) options.push('access_token=' + accessToken);
     request.abort();
     request.open(
-      "GET",
-      `${api}${profile}/${query}.json?${options.join("&")}`,
+      'GET',
+      `${api}${profile}/${query}.json?${options.join('&')}`,
       true
     );
 
@@ -127,23 +127,23 @@ function buildDirectionsQuery(state) {
   const { origin, destination, waypoints } = state();
 
   let query = [];
-  query.push(origin.geometry.coordinates.join(","));
-  query.push(";");
+  query.push(origin.geometry.coordinates.join(','));
+  query.push(';');
 
   // Add any waypoints.
   if (waypoints.length) {
     waypoints.forEach(waypoint => {
-      query.push(waypoint.geometry.coordinates.join(","));
-      query.push(";");
+      query.push(waypoint.geometry.coordinates.join(','));
+      query.push(';');
     });
   }
 
-  query.push(destination.geometry.coordinates.join(","));
-  return encodeURIComponent(query.join(""));
+  query.push(destination.geometry.coordinates.join(','));
+  return encodeURIComponent(query.join(''));
 }
 
 function normalizeWaypoint(waypoint) {
-  const properties = { id: "waypoint" };
+  const properties = { id: 'waypoint' };
   return Object.assign(waypoint, {
     properties: waypoint.properties
       ? Object.assign(waypoint.properties, properties)
@@ -154,10 +154,10 @@ function normalizeWaypoint(waypoint) {
 function setError(error) {
   return dispatch => {
     dispatch({
-      type: "ERROR",
+      type: 'ERROR',
       error
     });
-    if (error) dispatch(eventEmit("error", { error: error }));
+    if (error) dispatch(eventEmit('error', { error: error }));
   };
 }
 
@@ -194,7 +194,7 @@ export function clearOrigin() {
     dispatch({
       type: types.ORIGIN_CLEAR
     });
-    dispatch(eventEmit("clear", { type: "origin" }));
+    dispatch(eventEmit('clear', { type: 'origin' }));
     dispatch(setError(null));
   };
 }
@@ -204,7 +204,7 @@ export function clearDestination() {
     dispatch({
       type: types.DESTINATION_CLEAR
     });
-    dispatch(eventEmit("clear", { type: "destination" }));
+    dispatch(eventEmit('clear', { type: 'destination' }));
     dispatch(setError(null));
   };
 }
@@ -219,7 +219,7 @@ export function setOptions(options) {
 export function hoverMarker(coordinates) {
   return dispatch => {
     const feature = coordinates
-      ? utils.createPoint(coordinates, { id: "hover" })
+      ? utils.createPoint(coordinates, { id: 'hover' })
       : {};
     dispatch(setHoverMarker(feature));
   };
@@ -252,7 +252,7 @@ export function setProfile(profile) {
   return (dispatch, getState) => {
     const { origin, destination } = getState();
     dispatch({ type: types.DIRECTIONS_PROFILE, profile });
-    dispatch(eventEmit("profile", { profile }));
+    dispatch(eventEmit('profile', { profile }));
     if (origin.geometry && destination.geometry) dispatch(fetchDirections());
   };
 }
@@ -279,7 +279,7 @@ export function setOriginFromCoordinates(coords) {
     if (!utils.validCoords(coords))
       coords = [utils.wrap(coords[0]), utils.wrap(coords[1])];
     if (isNaN(coords[0]) && isNaN(coords[1]))
-      return dispatch(setError(new Error("Coordinates are not valid")));
+      return dispatch(setError(new Error('Coordinates are not valid')));
     dispatch(queryOriginCoordinates(coords));
     dispatch(createOrigin(coords));
   };
@@ -295,7 +295,7 @@ export function setDestinationFromCoordinates(coords) {
     if (!utils.validCoords(coords))
       coords = [utils.wrap(coords[0]), utils.wrap(coords[1])];
     if (isNaN(coords[0]) && isNaN(coords[1]))
-      return dispatch(setError(new Error("Coordinates are not valid")));
+      return dispatch(setError(new Error('Coordinates are not valid')));
     dispatch(createDestination(coords));
     dispatch(queryDestinationCoordinates(coords));
   };

--- a/src/directions.js
+++ b/src/directions.js
@@ -1,19 +1,19 @@
-import { createStore, applyMiddleware, bindActionCreators } from "redux";
-import thunk from "redux-thunk";
-import { decode } from "polyline";
-import utils from "./utils";
-import rootReducer from "./reducers";
+import { createStore, applyMiddleware, bindActionCreators } from 'redux';
+import thunk from 'redux-thunk';
+import { decode } from 'polyline';
+import utils from './utils';
+import rootReducer from './reducers';
 
 const storeWithMiddleware = applyMiddleware(thunk)(createStore);
 const store = storeWithMiddleware(rootReducer);
 
 // State object management via redux
-import * as actions from "./actions";
-import directionsStyle from "./directions_style";
+import * as actions from './actions';
+import directionsStyle from './directions_style';
 
 // Controls
-import Inputs from "./controls/inputs";
-import Instructions from "./controls/instructions";
+import Inputs from './controls/inputs';
+import Instructions from './controls/instructions';
 
 /**
  * The Directions control
@@ -69,17 +69,17 @@ export default class MapboxDirections {
 
     const { controls } = store.getState();
 
-    var el = (this.container = document.createElement("div"));
-    el.className = "mapboxgl-ctrl-directions mapboxgl-ctrl";
+    var el = (this.container = document.createElement('div'));
+    el.className = 'mapboxgl-ctrl-directions mapboxgl-ctrl';
 
     // Add controls to the page
-    const inputEl = document.createElement("div");
-    inputEl.className = "directions-control directions-control-inputs";
+    const inputEl = document.createElement('div');
+    inputEl.className = 'directions-control directions-control-inputs';
     new Inputs(inputEl, store, this.actions, this._map);
 
-    const directionsEl = document.createElement("div");
+    const directionsEl = document.createElement('div');
     directionsEl.className =
-      "directions-control directions-control-instructions";
+      'directions-control directions-control-instructions';
 
     new Instructions(
       directionsEl,
@@ -96,7 +96,7 @@ export default class MapboxDirections {
 
     this.subscribedActions();
     if (this._map.loaded()) this.mapState();
-    else this._map.on("load", () => this.mapState());
+    else this._map.on('load', () => this.mapState());
 
     return el;
   }
@@ -110,11 +110,11 @@ export default class MapboxDirections {
   onRemove(map) {
     this.container.parentNode.removeChild(this.container);
     this.removeRoutes();
-    map.off("mousedown", this.onDragDown);
-    map.off("mousemove", this.move);
-    map.off("touchstart", this.onDragDown);
-    map.off("touchstart", this.move);
-    map.off("click", this.onClick);
+    map.off('mousedown', this.onDragDown);
+    map.off('mousemove', this.move);
+    map.off('touchstart', this.onDragDown);
+    map.off('touchstart', this.move);
+    map.off('click', this.onClick);
     if (this.storeUnsubscribe) {
       this.storeUnsubscribe();
       delete this.storeUnsubscribe;
@@ -123,7 +123,7 @@ export default class MapboxDirections {
       if (map.getLayer(layer.id)) map.removeLayer(layer.id);
     });
 
-    if (map.getSource("directions")) map.removeSource("directions");
+    if (map.getSource('directions')) map.removeSource('directions');
 
     this._map = null;
     return this;
@@ -140,18 +140,18 @@ export default class MapboxDirections {
     } = store.getState();
 
     // Emit any default or option set config
-    this.actions.eventEmit("profile", { profile });
+    this.actions.eventEmit('profile', { profile });
 
     const geojson = {
-      type: "geojson",
+      type: 'geojson',
       data: {
-        type: "FeatureCollection",
+        type: 'FeatureCollection',
         features: []
       }
     };
 
     // Add and set data theme layer/style
-    this._map.addSource("directions", geojson);
+    this._map.addSource('directions', geojson);
 
     // Add direction specific styles to the map
     if (styles && styles.length)
@@ -162,12 +162,12 @@ export default class MapboxDirections {
     });
 
     if (interactive) {
-      this._map.on("mousedown", this.onDragDown);
-      this._map.on("mousemove", this.move);
-      this._map.on("click", this.onClick);
+      this._map.on('mousedown', this.onDragDown);
+      this._map.on('mousemove', this.move);
+      this._map.on('click', this.onClick);
 
-      this._map.on("touchstart", this.move);
-      this._map.on("touchstart", this.onDragDown);
+      this._map.on('touchstart', this.move);
+      this._map.on('touchstart', this.onDragDown);
     }
   }
 
@@ -182,7 +182,7 @@ export default class MapboxDirections {
       } = store.getState();
 
       const geojson = {
-        type: "FeatureCollection",
+        type: 'FeatureCollection',
         features: [origin, destination, hoverMarker].filter(d => {
           return d.geometry;
         })
@@ -211,12 +211,12 @@ export default class MapboxDirections {
             } else {
               var segment = {
                 geometry: {
-                  type: "LineString",
+                  type: 'LineString',
                   coordinates: []
                 },
                 properties: {
-                  "route-index": index,
-                  route: index === routeIndex ? "selected" : "alternate"
+                  'route-index': index,
+                  route: index === routeIndex ? 'selected' : 'alternate'
                 }
               };
 
@@ -244,12 +244,12 @@ export default class MapboxDirections {
           if (index === routeIndex) {
             // Collect any possible waypoints from steps
             feature.legs[0].steps.forEach(d => {
-              if (d.maneuver.type === "waypoint") {
+              if (d.maneuver.type === 'waypoint') {
                 geojson.features.push({
-                  type: "Feature",
+                  type: 'Feature',
                   geometry: d.maneuver.location,
                   properties: {
-                    id: "waypoint"
+                    id: 'waypoint'
                   }
                 });
               }
@@ -258,8 +258,8 @@ export default class MapboxDirections {
         });
       }
 
-      if (this._map.style && this._map.getSource("directions")) {
-        this._map.getSource("directions").setData(geojson);
+      if (this._map.style && this._map.getSource('directions')) {
+        this._map.getSource('directions').setData(geojson);
       }
     });
   }
@@ -292,23 +292,23 @@ export default class MapboxDirections {
     } else {
       const features = this._map.queryRenderedFeatures(e.point, {
         layers: [
-          "directions-origin-point",
-          "directions-destination-point",
-          "directions-waypoint-point",
-          "directions-route-line-alt"
+          'directions-origin-point',
+          'directions-destination-point',
+          'directions-waypoint-point',
+          'directions-route-line-alt'
         ]
       });
 
       if (features.length) {
         // Remove any waypoints
         features.forEach(f => {
-          if (f.layer.id === "directions-waypoint-point") {
+          if (f.layer.id === 'directions-waypoint-point') {
             this.actions.removeWaypoint(f);
           }
         });
 
-        if (features[0].properties.route === "alternate") {
-          const index = features[0].properties["route-index"];
+        if (features[0].properties.route === 'alternate') {
+          const index = features[0].properties['route-index'];
           this.actions.setRouteIndex(index);
         }
       } else {
@@ -323,15 +323,15 @@ export default class MapboxDirections {
 
     const features = this._map.queryRenderedFeatures(e.point, {
       layers: [
-        "directions-route-line-alt",
-        "directions-route-line",
-        "directions-origin-point",
-        "directions-destination-point",
-        "directions-hover-point"
+        'directions-route-line-alt',
+        'directions-route-line',
+        'directions-origin-point',
+        'directions-destination-point',
+        'directions-hover-point'
       ]
     });
 
-    this._map.getCanvas().style.cursor = features.length ? "pointer" : "";
+    this._map.getCanvas().style.cursor = features.length ? 'pointer' : '';
 
     if (features.length) {
       this.isCursorOverPoint = features[0];
@@ -339,7 +339,7 @@ export default class MapboxDirections {
 
       // Add a possible waypoint marker when hovering over the active route line
       features.forEach(feature => {
-        if (feature.layer.id === "directions-route-line") {
+        if (feature.layer.id === 'directions-route-line') {
           this.actions.hoverMarker([e.lngLat.lng, e.lngLat.lat]);
         } else if (hoverMarker.geometry) {
           this.actions.hoverMarker(null);
@@ -354,13 +354,13 @@ export default class MapboxDirections {
   _onDragDown() {
     if (!this.isCursorOverPoint) return;
     this.isDragging = this.isCursorOverPoint;
-    this._map.getCanvas().style.cursor = "grab";
+    this._map.getCanvas().style.cursor = 'grab';
 
-    this._map.on("mousemove", this.onDragMove);
-    this._map.on("mouseup", this.onDragUp);
+    this._map.on('mousemove', this.onDragMove);
+    this._map.on('mouseup', this.onDragUp);
 
-    this._map.on("touchmove", this.onDragMove);
-    this._map.on("touchend", this.onDragUp);
+    this._map.on('touchmove', this.onDragMove);
+    this._map.on('touchend', this.onDragUp);
   }
 
   _onDragMove(e) {
@@ -368,13 +368,13 @@ export default class MapboxDirections {
 
     const coords = [e.lngLat.lng, e.lngLat.lat];
     switch (this.isDragging.layer.id) {
-      case "directions-origin-point":
+      case 'directions-origin-point':
         this.actions.createOrigin(coords);
         break;
-      case "directions-destination-point":
+      case 'directions-destination-point':
         this.actions.createDestination(coords);
         break;
-      case "directions-hover-point":
+      case 'directions-hover-point':
         this.actions.hoverMarker(coords);
         break;
     }
@@ -386,15 +386,15 @@ export default class MapboxDirections {
     const { hoverMarker, origin, destination } = store.getState();
 
     switch (this.isDragging.layer.id) {
-      case "directions-origin-point":
+      case 'directions-origin-point':
         this.actions.setOriginFromCoordinates(origin.geometry.coordinates);
         break;
-      case "directions-destination-point":
+      case 'directions-destination-point':
         this.actions.setDestinationFromCoordinates(
           destination.geometry.coordinates
         );
         break;
-      case "directions-hover-point":
+      case 'directions-hover-point':
         // Add waypoint if a sufficent amount of dragging has occurred.
         if (
           hoverMarker.geometry &&
@@ -406,13 +406,13 @@ export default class MapboxDirections {
     }
 
     this.isDragging = false;
-    this._map.getCanvas().style.cursor = "";
+    this._map.getCanvas().style.cursor = '';
 
-    this._map.off("touchmove", this.onDragMove);
-    this._map.off("touchend", this.onDragUp);
+    this._map.off('touchmove', this.onDragMove);
+    this._map.off('touchend', this.onDragUp);
 
-    this._map.off("mousemove", this.onDragMove);
-    this._map.off("mouseup", this.onDragUp);
+    this._map.off('mousemove', this.onDragMove);
+    this._map.off('mouseup', this.onDragUp);
   }
 
   // API Methods
@@ -425,19 +425,19 @@ export default class MapboxDirections {
    */
   interactive(state) {
     if (state) {
-      this._map.on("touchstart", this.move);
-      this._map.on("touchstart", this.onDragDown);
+      this._map.on('touchstart', this.move);
+      this._map.on('touchstart', this.onDragDown);
 
-      this._map.on("mousedown", this.onDragDown);
-      this._map.on("mousemove", this.move);
-      this._map.on("click", this.onClick);
+      this._map.on('mousedown', this.onDragDown);
+      this._map.on('mousemove', this.move);
+      this._map.on('click', this.onClick);
     } else {
-      this._map.off("touchstart", this.move);
-      this._map.off("touchstart", this.onDragDown);
+      this._map.off('touchstart', this.move);
+      this._map.off('touchstart', this.onDragDown);
 
-      this._map.off("mousedown", this.onDragDown);
-      this._map.off("mousemove", this.move);
-      this._map.off("click", this.onClick);
+      this._map.off('mousedown', this.onDragDown);
+      this._map.off('mousemove', this.move);
+      this._map.off('click', this.onClick);
     }
 
     return this;
@@ -458,7 +458,7 @@ export default class MapboxDirections {
    * @returns {MapboxDirections} this
    */
   setOrigin(query) {
-    if (typeof query === "string") {
+    if (typeof query === 'string') {
       this.actions.queryOrigin(query);
     } else {
       this.actions.setOriginFromCoordinates(query);
@@ -482,7 +482,7 @@ export default class MapboxDirections {
    * @returns {MapboxDirections} this
    */
   setDestination(query) {
-    if (typeof query === "string") {
+    if (typeof query === 'string') {
       this.actions.queryDestination(query);
     } else {
       this.actions.setDestinationFromCoordinates(query);
@@ -509,7 +509,7 @@ export default class MapboxDirections {
    */
   addWaypoint(index, waypoint) {
     if (!waypoint.type)
-      waypoint = utils.createPoint(waypoint, { id: "waypoint" });
+      waypoint = utils.createPoint(waypoint, { id: 'waypoint' });
     this.actions.addWaypoint(index, waypoint);
     return this;
   }
@@ -524,7 +524,7 @@ export default class MapboxDirections {
    */
   setWaypoint(index, waypoint) {
     if (!waypoint.type)
-      waypoint = utils.createPoint(waypoint, { id: "waypoint" });
+      waypoint = utils.createPoint(waypoint, { id: 'waypoint' });
     this.actions.setWaypoint(index, waypoint);
     return this;
   }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,16 +1,17 @@
-import * as types from '../constants/action_types.js';
-import deepAssign from 'deep-assign';
+import * as types from "../constants/action_types.js";
+import deepAssign from "deep-assign";
 
 const initialState = {
   // Options set on initialization
-  api: 'https://api.mapbox.com/directions/v5/',
-  profile: 'mapbox/driving-traffic',
+  api: "https://api.mapbox.com/directions/v5/",
+  profile: "mapbox/driving-traffic",
   alternatives: false,
   congestion: false,
-  unit: 'imperial',
+  overview: "simplified",
+  unit: "imperial",
   flyTo: true,
-  placeholderOrigin: 'Choose a starting place',
-  placeholderDestination: 'Choose destination',
+  placeholderOrigin: "Choose a starting place",
+  placeholderDestination: "Choose destination",
   zoom: 16,
   compile: null,
   proximity: false,
@@ -50,89 +51,89 @@ const initialState = {
 
 function data(state = initialState, action) {
   switch (action.type) {
-  case types.SET_OPTIONS:
-    return deepAssign({}, state, action.options);
+    case types.SET_OPTIONS:
+      return deepAssign({}, state, action.options);
 
-  case types.DIRECTIONS_PROFILE:
-    return Object.assign({}, state, {
-      profile: action.profile
-    });
+    case types.DIRECTIONS_PROFILE:
+      return Object.assign({}, state, {
+        profile: action.profile
+      });
 
-  case types.ORIGIN:
-    return Object.assign({}, state, {
-      origin: action.origin,
-      hoverMarker: {}
-    });
+    case types.ORIGIN:
+      return Object.assign({}, state, {
+        origin: action.origin,
+        hoverMarker: {}
+      });
 
-  case types.DESTINATION:
-    return Object.assign({}, state, {
-      destination: action.destination,
-      hoverMarker: {}
-    });
+    case types.DESTINATION:
+      return Object.assign({}, state, {
+        destination: action.destination,
+        hoverMarker: {}
+      });
 
-  case types.HOVER_MARKER:
-    return Object.assign({}, state, {
-      hoverMarker: action.hoverMarker
-    });
+    case types.HOVER_MARKER:
+      return Object.assign({}, state, {
+        hoverMarker: action.hoverMarker
+      });
 
-  case types.WAYPOINTS:
-    return Object.assign({}, state, {
-      waypoints: action.waypoints
-    });
+    case types.WAYPOINTS:
+      return Object.assign({}, state, {
+        waypoints: action.waypoints
+      });
 
-  case types.ORIGIN_QUERY:
-    return Object.assign({}, state, {
-      originQuery: action.query
-    });
+    case types.ORIGIN_QUERY:
+      return Object.assign({}, state, {
+        originQuery: action.query
+      });
 
-  case types.DESTINATION_QUERY:
-    return Object.assign({}, state, {
-      destinationQuery: action.query
-    });
+    case types.DESTINATION_QUERY:
+      return Object.assign({}, state, {
+        destinationQuery: action.query
+      });
 
-  case types.ORIGIN_FROM_COORDINATES:
-    return Object.assign({}, state, {
-      originQueryCoordinates: action.coordinates
-    });
+    case types.ORIGIN_FROM_COORDINATES:
+      return Object.assign({}, state, {
+        originQueryCoordinates: action.coordinates
+      });
 
-  case types.DESTINATION_FROM_COORDINATES:
-    return Object.assign({}, state, {
-      destinationQueryCoordinates: action.coordinates
-    });
+    case types.DESTINATION_FROM_COORDINATES:
+      return Object.assign({}, state, {
+        destinationQueryCoordinates: action.coordinates
+      });
 
-  case types.ORIGIN_CLEAR:
-    return Object.assign({}, state, {
-      origin: {},
-      originQuery: '',
-      waypoints: [],
-      directions: []
-    });
+    case types.ORIGIN_CLEAR:
+      return Object.assign({}, state, {
+        origin: {},
+        originQuery: "",
+        waypoints: [],
+        directions: []
+      });
 
-  case types.DESTINATION_CLEAR:
-    return Object.assign({}, state, {
-      destination: {},
-      destinationQuery: '',
-      waypoints: [],
-      directions: []
-    });
+    case types.DESTINATION_CLEAR:
+      return Object.assign({}, state, {
+        destination: {},
+        destinationQuery: "",
+        waypoints: [],
+        directions: []
+      });
 
-  case types.DIRECTIONS:
-    return Object.assign({}, state, {
-      directions: action.directions
-    });
+    case types.DIRECTIONS:
+      return Object.assign({}, state, {
+        directions: action.directions
+      });
 
-  case types.ROUTE_INDEX:
-    return Object.assign({}, state, {
-      routeIndex: action.routeIndex
-    });
+    case types.ROUTE_INDEX:
+      return Object.assign({}, state, {
+        routeIndex: action.routeIndex
+      });
 
-  case types.ERROR:
-    return Object.assign({}, state, {
-      error: action.error
-    });
+    case types.ERROR:
+      return Object.assign({}, state, {
+        error: action.error
+      });
 
-  default:
-    return state;
+    default:
+      return state;
   }
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,17 +1,17 @@
-import * as types from "../constants/action_types.js";
-import deepAssign from "deep-assign";
+import * as types from '../constants/action_types.js';
+import deepAssign from 'deep-assign';
 
 const initialState = {
   // Options set on initialization
-  api: "https://api.mapbox.com/directions/v5/",
-  profile: "mapbox/driving-traffic",
+  api: 'https://api.mapbox.com/directions/v5/',
+  profile: 'mapbox/driving-traffic',
   alternatives: false,
   congestion: false,
-  overview: "simplified",
-  unit: "imperial",
+  overview: 'simplified',
+  unit: 'imperial',
   flyTo: true,
-  placeholderOrigin: "Choose a starting place",
-  placeholderDestination: "Choose destination",
+  placeholderOrigin: 'Choose a starting place',
+  placeholderDestination: 'Choose destination',
   zoom: 16,
   compile: null,
   proximity: false,
@@ -104,7 +104,7 @@ function data(state = initialState, action) {
     case types.ORIGIN_CLEAR:
       return Object.assign({}, state, {
         origin: {},
-        originQuery: "",
+        originQuery: '',
         waypoints: [],
         directions: []
       });
@@ -112,7 +112,7 @@ function data(state = initialState, action) {
     case types.DESTINATION_CLEAR:
       return Object.assign({}, state, {
         destination: {},
-        destinationQuery: "",
+        destinationQuery: '',
         waypoints: [],
         directions: []
       });


### PR DESCRIPTION
Hello,

Currently the overview query parameter of the Directions API is set to `full`, which could results a massive payload to download.
The API's default is `simplified`. As a consequence, it would be interesting to allow this option to be changed to the value that suited the use case.

Thank you.