### PR TITLE
Fix: Renderer does not check the flyTo parameter

### DIFF
--- a/src/controls/inputs.js
+++ b/src/controls/inputs.js
@@ -122,7 +122,8 @@ export default class Inputs {
         originQuery,
         destinationQuery,
         originQueryCoordinates,
-        destinationQueryCoordinates
+        destinationQueryCoordinates,
+        flyTo
       } = this.store.getState();
 
       if (originQuery) {
@@ -137,13 +138,17 @@ export default class Inputs {
 
       if (originQueryCoordinates) {
         this.originInput.setInput(originQueryCoordinates);
-        this.animateToCoordinates('origin', originQueryCoordinates);
+        if (flyTo) {
+            this.animateToCoordinates('origin', originQueryCoordinates);
+        }
         this.actions.queryOriginCoordinates(null);
       }
 
       if (destinationQueryCoordinates) {
         this.destinationInput.setInput(destinationQueryCoordinates);
-        this.animateToCoordinates('destination', destinationQueryCoordinates);
+        if (flyTo) {
+            this.animateToCoordinates('destination', destinationQueryCoordinates);
+        }
         this.actions.queryDestinationCoordinates(null);
       }
     });


### PR DESCRIPTION
We use the component to create scenic routes, I've created a route editor where the user can add waypoints. In our use case, the source/destination are not really relevant, and when updating the route, it is undesirable that the map switches coordinates.
On result in the onAdd function, the 'flyTo' parameter seems to be ignored.