### PR TITLE
Fix bug where re-adding component on style change fails

### DIFF
--- a/src/directions.js
+++ b/src/directions.js
@@ -91,8 +91,22 @@ export default class MapboxDirections {
     if (controls.instructions) el.appendChild(directionsEl);
 
     this.subscribedActions();
-    if (this._map.loaded()) this.mapState()
-    else this._map.on('load', () => this.mapState());
+    
+    /*
+     * We are subscribing to idle here instead of load as loaded() returns true if
+     * the map is loading at any time, but the load event only triggers on the first
+     * complete load. This means if we are changing style after the first load and are
+     * trying to add the component, it will not add anything subscribed to load.
+     */
+    var _this5 = this;
+    if (this._map.loaded()) {
+      this.mapState();
+    } else {
+      this._map.on('idle', function onMapIdleSetState() {
+        _this5._map.off('idle', onMapIdleSetState);
+        _this5.mapState();
+      });
+    }
 
     return el;
   }


### PR DESCRIPTION
The goal of this PR is to fix #190 

Currently if a user of Mapbox GL JS is using this component and they want to switch styles, they need to remove and re-add the directions component.  But due to how the onAdd function works, it will not trigger the re-addition of some styles, as it will wait for a load event that will never come.  Instead this subscribes to the idle event and then unsubscribes itself once it has triggered.

Please let me know if I can improve the PR in any way :)

