### PR TITLE
Remove dropdown suggestions when reversing origin and destination

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -244,6 +244,10 @@ export function reverse() {
     if (state.destination.geometry) dispatch(originPoint(state.destination.geometry.coordinates));
     if (state.origin.geometry) dispatch(destinationPoint(state.origin.geometry.coordinates));
     if (state.origin.geometry && state.destination.geometry) dispatch(fetchDirections());
+    const suggestions = document.getElementsByClassName("suggestions");
+    for (var i = 0; i < suggestions.length; i++) {
+      suggestions[i].style.visibility = "hidden";
+    };
   };
 }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -244,9 +244,9 @@ export function reverse() {
     if (state.destination.geometry) dispatch(originPoint(state.destination.geometry.coordinates));
     if (state.origin.geometry) dispatch(destinationPoint(state.origin.geometry.coordinates));
     if (state.origin.geometry && state.destination.geometry) dispatch(fetchDirections());
-    const suggestions = document.getElementsByClassName("suggestions");
+    const suggestions = document.getElementsByClassName('suggestions');
     for (var i = 0; i < suggestions.length; i++) {
-      suggestions[i].style.visibility = "hidden";
+      suggestions[i].style.visibility = 'hidden';
     };
   };
 }


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-directions/issues/245

With the current behavior, when reversing origin and destination, dropdown suggestions are displayed again which leads to a confusing UI. 

![reverse-fix2](https://user-images.githubusercontent.com/19801577/80176331-11a3b800-85ad-11ea-8d75-ce0ff1c84466.gif)

Proposed behavior simply reverses the points (and step-by-step directions) and hides suggestions when reversing. 

![reverse-fix1](https://user-images.githubusercontent.com/19801577/80176334-12d4e500-85ad-11ea-942f-ecdb3b3229dd.gif)
