### PR TITLE
Fix input reverse autocomplete behavior

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -244,10 +244,6 @@ export function reverse() {
     if (state.destination.geometry) dispatch(originPoint(state.destination.geometry.coordinates));
     if (state.origin.geometry) dispatch(destinationPoint(state.origin.geometry.coordinates));
     if (state.origin.geometry && state.destination.geometry) dispatch(fetchDirections());
-    const suggestions = document.getElementsByClassName('suggestions');
-    for (var i = 0; i < suggestions.length; i++) {
-      suggestions[i].style.visibility = 'hidden';
-    };
   };
 }
 

--- a/src/controls/inputs.js
+++ b/src/controls/inputs.js
@@ -109,8 +109,10 @@ export default class Inputs {
       .querySelector('.js-reverse-inputs')
       .addEventListener('click', () => {
         const { origin, destination } = this.store.getState();
-        if (origin) this.actions.queryDestination(origin.geometry.coordinates);
-        if (destination) this.actions.queryOrigin(destination.geometry.coordinates);
+        var originElement = document.getElementById('mapbox-directions-origin-input').querySelector('input').value;
+        var destinationElement = document.getElementById('mapbox-directions-destination-input').querySelector('input').value;
+        if (origin) this.originInput.setInput(destinationElement);
+        if (destination) this.destinationInput.setInput(originElement);
         reverse();
       });
   }


### PR DESCRIPTION
Adding visibility:hidden to autocomplete on input reverse also disables autocomplete when searching after reversing directions. 

<img width="860" alt="Screen Shot 2020-08-03 at 9 27 51 PM" src="https://user-images.githubusercontent.com/19801577/89253015-407bf200-d5d0-11ea-8e04-2d8f7bf6cb50.png">

This PR fixes this behavior by simply swapping the text input when the reverse button is clicked.
