### PR TITLE
Exclude options.api from query params

### DIFF
--- a/src/controls/geocoder.js
+++ b/src/controls/geocoder.js
@@ -93,7 +93,7 @@ export default class Geocoder {
     this.fire('loading');
 
     const geocodingOptions = this.options
-    const exclude = ['placeholder', 'zoom', 'flyTo', 'accessToken'];
+    const exclude = ['placeholder', 'zoom', 'flyTo', 'accessToken', 'api'];
     const options = Object.keys(this.options).filter(function(key) {
       return exclude.indexOf(key) === -1;
     }).map(function(key) {


### PR DESCRIPTION
Since mapbox-gl-directions 4.0.0, specifying a custom API for the geocoder control has worked, but also inserts the `api` option as a query parameter, leading to requests like `https://api2.mapbox.com/geocoding/v5/mapbox.places/test.json?api=https://api2.mapbox.com/geocoding/v5/mapbox.places/&access_token=`

While this doesn't cause an error, it isn't the desired behavior. This PR adds `api` to the list of geocoder options excluded from the URL parameters.