### PR TITLE
Fix the duration and distance values

### DIFF
--- a/src/controls/instructions.js
+++ b/src/controls/instructions.js
@@ -52,8 +52,8 @@ export default class Instructions {
           routes: directions.length,
           steps: direction.legs[0].steps, // Todo: Respect all legs,
           format: utils.format[unit],
-          duration: utils.format[unit](direction.distance),
-          distance: utils.format.duration(direction.duration)
+          duration: utils.format.duration(direction.duration),
+          distance: utils.format[unit](direction.distance)
         });
 
         const steps = this.container.querySelectorAll('.mapbox-directions-step');


### PR DESCRIPTION
Hi

I have a question about this.
They seem to be given the wrong values for the duration and distance variables.

![mapbox-gl-direction-duration-and-distance-should-be-exchanged](https://user-images.githubusercontent.com/24354061/103460888-f781c280-4d54-11eb-8492-fa257ccda111.png)

In [src/controls/instructions.js on lines 55 and 56](https://github.com/YuChunTsao/mapbox-gl-directions/blob/master/src/controls/instructions.js#L55-L56)
```js
duration: utils.format[unit](direction.distance),
distance: utils.format.duration(direction.duration)
```
The duration and distance values should be exchanged
like this

```js
duration: utils.format.duration(direction.duration),
distance: utils.format[unit](direction.distance)
```