### PR TITLE
Catch 'No Route found' response

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -80,8 +80,8 @@ function fetchDirections() {
         }
         
         // Catch no route responses and display message to user
-        if (data.message === "No route found") {
-          return dispatch(setError("No route found"));
+        if (data.message === 'No route found') {
+          return dispatch(setError('No route found'));
         }
 
         dispatch(setError(null));

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -79,6 +79,10 @@ function fetchDirections() {
           return dispatch(setError(data.error));
         }
 
+        if (data.message === "No route found") {
+          return dispatch(setError("No route found"));
+        }
+
         dispatch(setError(null));
         if (!data.routes[routeIndex]) dispatch(setRouteIndex(0));
         dispatch(setDirections(data.routes));
@@ -93,6 +97,7 @@ function fetchDirections() {
     };
 
     request.onerror = () => {
+      console.log('on error')
       dispatch(setDirections([]));
       return dispatch(setError(JSON.parse(request.responseText).message));
     };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -97,7 +97,6 @@ function fetchDirections() {
     };
 
     request.onerror = () => {
-      console.log('on error')
       dispatch(setDirections([]));
       return dispatch(setError(JSON.parse(request.responseText).message));
     };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -79,7 +79,7 @@ function fetchDirections() {
           return dispatch(setError(data.error));
         }
         
-        // Catch no route responses
+        // Catch no route responses and display message to user
         if (data.message === "No route found") {
           return dispatch(setError("No route found"));
         }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -78,7 +78,8 @@ function fetchDirections() {
           dispatch(setDirections([]));
           return dispatch(setError(data.error));
         }
-
+        
+        // Catch no route responses
         if (data.message === "No route found") {
           return dispatch(setError("No route found"));
         }


### PR DESCRIPTION
Currently routes that return 'No route found' cause the following error: 

```
TypeError: Cannot read property '0' of undefined
  at XMLHttpRequest.request.onload (/mapbox-gl-js/plugins/mapbox-gl-directions/v3.1.1/mapbox-gl-directions.js:5819:44)
```
![image](https://user-images.githubusercontent.com/19801577/139136766-41b6bdf2-e78c-4e1c-8e9e-10b4e3dfa461.png)

This change catches these responses and displays the appropriate message to the user (see screenshot above). 
