### PR TITLE
fix: request is loaded after removeRoutes() is called

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -189,6 +189,7 @@ export function clearOrigin() {
 }
 
 export function clearDestination() {
+  request.abort();
   return dispatch => {
     dispatch({
       type: types.DESTINATION_CLEAR


### PR DESCRIPTION
Currently the removeRoutes() function doesn't abort any ongoing requests which may cause the symbols to be redrawn on the map after calling removeRoutes()

This bug occurs frequentally to users with slow internet as the request may take longer time to be loaded while the removeRoutes() was already called