### PR TITLE
Refactor CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   aws-cli: circleci/aws-cli@3.1.4
   browser-tools: circleci/browser-tools@1.4.0
+
 workflows:
   version: 2
   default:
@@ -39,19 +40,21 @@ workflows:
       - publish:
           requires:
             - build
+            - install-mbx-ci
           filters:
             tags:
               only: '/v[0-9]+\.[0-9]+\.[0-9]+(\-dev)?/'
             branches:
               ignore: /.*/
-defaults:
-  docker: &ref_0
-    - image: 'cimg/node:18.12-browsers'
+
+defaults: &defaults
+  docker:
+    - image: cimg/node:18.12-browsers
   working_directory: ~/mapbox-gl-directions
+
 jobs:
   prepare:
-    docker: *ref_0
-    working_directory: ~/mapbox-gl-directions
+    <<: *defaults
     steps:
       - checkout
       - restore_cache:
@@ -62,12 +65,13 @@ jobs:
           paths:
             - node_modules
       - persist_to_workspace:
-          root: .
+          root: ~/
           paths:
-            - .
+            - .ssh
+            - mapbox-gl-directions
+
   install-mbx-ci:
-    docker: *ref_0
-    working_directory: ~/mapbox-gl-directions
+    <<: *defaults
     steps:
       - run:
           name: Install mbx-ci
@@ -80,25 +84,25 @@ jobs:
             - .ssh
             - .aws
             - mbx-ci
+
   build:
-    docker: *ref_0
-    working_directory: ~/mapbox-gl-directions
+    <<: *defaults
     steps:
       - attach_workspace:
-          at: .
+          at: ~/
       - run: npm run build
       - store_artifacts:
           path: dist
       - persist_to_workspace:
-          root: .
+          root: ~/
           paths:
-            - dist
+            - mapbox-gl-directions/dist
+
   lint:
-    docker: *ref_0
-    working_directory: ~/mapbox-gl-directions
+    <<: *defaults
     steps:
       - attach_workspace:
-          at: .
+          at: ~/
       - restore_cache:
           keys:
             - 'v2-lint-{{ .Branch }}'
@@ -108,25 +112,24 @@ jobs:
           key: 'v2-lint-{{ .Branch }}-{{ .Revision }}'
           paths:
             - .eslintcache
+
   test:
-    docker: *ref_0
-    working_directory: ~/mapbox-gl-directions
+    <<: *defaults
     steps:
       - attach_workspace:
-          at: .
+          at: ~/
       - browser-tools/install-firefox
       - run: npm run test
+
   publish:
-    docker: *ref_0
-    working_directory: ~/mapbox-gl-directions
+    <<: *defaults
     steps:
       - attach_workspace:
-          at: .
+          at: ~/
       - aws-cli/install
       - run:
           name: Setup AWS
           command: |
              ~/mbx-ci aws setup
       - run: >-
-          aws s3 cp --recursive --acl public-read dist
-          s3://mapbox-gl-js/plugins/mapbox-gl-directions/$CIRCLE_TAG
+          aws s3 cp --recursive --acl public-read dist s3://mapbox-gl-js/plugins/mapbox-gl-directions/$CIRCLE_TAG


### PR DESCRIPTION
Simplify and align with the Mapbox GL JS CircleCI config, `publish` job now requires `install-mbx-ci` job.