### PR TITLE
update mapboxgl peer dependency versions, update contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ### Developing
 
-    yarn install & yarn start & open http://localhost:9966/example/
+    npm install & npm start & open http://localhost:9966/
 
 You'll need a [Mapbox access token](https://www.mapbox.com/help/create-api-access-token/) stored in localstorage. Set it via
 
@@ -10,7 +10,7 @@ You'll need a [Mapbox access token](https://www.mapbox.com/help/create-api-acces
 
 Tests require an MapboxAccessToken env variable to be set.
 
-    export MapboxAccessToken=<YOUR ACCESS TOKEN> && yarn test
+    export MapboxAccessToken=<YOUR ACCESS TOKEN> && npm test
 
 ### Release process
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ var directions = new MapboxDirections({
 
 var map = new mapboxgl.Map({
   container: 'map',
-  style: 'mapbox://styles/mapbox/streets-v9'
+  style: 'mapbox://styles/mapbox/streets-v12'
 });
 
 map.addControl(directions, 'top-left');

--- a/example/index.js
+++ b/example/index.js
@@ -15,7 +15,7 @@ mapDiv.style = 'position:absolute;top:0;right:0;left:0;bottom:0;';
 var map = window.map = new mapboxgl.Map({
   hash: true,
   container: mapDiv,
-  style: 'mapbox://styles/mapbox/streets-v9',
+  style: 'mapbox://styles/mapbox/streets-v12',
   center: [-79.4512, 43.6568],
   zoom: 13
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@mapbox/mapbox-gl-directions",
-      "version": "4.2.0",
+      "version": "4.1.1",
       "license": "ISC",
       "dependencies": {
         "@mapbox/polyline": "^1.1.1",
@@ -43,7 +43,7 @@
         "webworkify-webpack": "^2.1.5"
       },
       "peerDependencies": {
-        "mapbox-gl": "^0.41.0 <2.0.0"
+        "mapbox-gl": "^2.13.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     ]
   },
   "peerDependencies": {
-    "mapbox-gl": "^0.41.0 <2.0.0"
+    "mapbox-gl": "^1 || ^2"
   },
   "scripts": {
     "prepublish": "npm run build",


### PR DESCRIPTION
* Updates mapboxgl peer dependency to `v1 || v2` so that those using modern versions of mapboxgl will not see a dependency warning.

* Updates `example.js`to use `streets-v12` style (instead of v9)

* Minor update to contributing.md to show `npm` commands instead of `yarn` commands.  (Not sure what the right answer here is, but the repo has a `package.lock` and not a `yarn.lock`.  There is some record in the changelog about switching to yarn to avoid some error but I am not sure that it is relevant anymore)