### PR TITLE
Release 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.2.0
+
+- [feature] Display waypoints-related instructions [#310](https://github.com/mapbox/mapbox-gl-directions/pull/310)
+- [chore] Update mapbox-gl peer dependency to support version 3 [#310](https://github.com/mapbox/mapbox-gl-directions/pull/310)
+- [chore] Fixed launching of tests [#310](https://github.com/mapbox/mapbox-gl-directions/pull/310)
+
 ## 4.1.2
 
 - [chore] Update mapbox-gl peer dependency version [#298](https://github.com/mapbox/mapbox-gl-directions/pull/298)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-directions",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-directions",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "A mapboxgl plugin for the Mapbox Directions API",
   "main": "./src/index.js",
   "browserify": {


### PR DESCRIPTION
- [feature] Display waypoints-related instructions [#310](https://github.com/mapbox/mapbox-gl-directions/pull/310)
- [chore] Update mapbox-gl peer dependency to support version 3 [#310](https://github.com/mapbox/mapbox-gl-directions/pull/310)
- [chore] Fixed launching of tests [#310](https://github.com/mapbox/mapbox-gl-directions/pull/310)