### PR TITLE
Replaced lodash.merge with merge-options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3256,14 +3256,6 @@
         "character-entities": "^2.0.0"
       }
     },
-    "deep-assign": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
-      "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
-      "requires": {
-        "is-obj": "^1.0.0"
-      }
-    },
     "deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -5276,11 +5268,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-    },
     "is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -5904,7 +5891,8 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -6402,6 +6390,21 @@
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
           }
+        }
+      }
+    },
+    "merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "requires": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -68,11 +68,10 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.1",
-    "deep-assign": "^3.0.0",
     "lodash.debounce": "^4.0.6",
     "lodash.isequal": "^4.2.0",
-    "lodash.merge": "^4.6.2",
     "lodash.template": "^4.2.5",
+    "merge-options": "^3.0.4",
     "redux": "^4.2.0",
     "redux-thunk": "^2.4.2",
     "suggestions": "^1.7.1",

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,7 +1,7 @@
 import * as types from '../constants/action_types.js';
-import merge from 'lodash.merge';
+import merge from 'merge-options';
 
-const initialState = {
+const getInitialState = () => ({
   // Options set on initialization
   api: 'https://api.mapbox.com/directions/v5/',
   profile: 'mapbox/driving-traffic',
@@ -49,9 +49,9 @@ const initialState = {
   fetchDirectionsRequest: null,
   routeIndex: 0, 
   routePadding: 80
-};
+});
 
-function data(state = initialState, action) {
+function data(state = getInitialState(), action) {
   switch (action.type) {
   case types.SET_OPTIONS: {
     return merge({}, state, action.options);


### PR DESCRIPTION
Replaced `lodash.merge` with `merge-options` (based on [two options recommended in deprecation notice](https://www.npmjs.com/package/deep-assign) of `deep-assign` library). Noticed, that `lodash.merge` added ~50KB of code, which significantly increase size of bundle without proper reason for that. Now situation with `merge-options` much better:

- `lodash.merge` 50.1KB
- `merge-options` 4.1 KB
- `deep-assign` 1.3 KB

![image](https://github.com/mapbox/mapbox-gl-directions/assets/2480721/5c8e76fa-35b2-4ba3-b75a-faeb24031bfd)
![image](https://github.com/mapbox/mapbox-gl-directions/assets/2480721/7e15152e-b74a-4825-99cb-a600961cf247)
![image](https://github.com/mapbox/mapbox-gl-directions/assets/2480721/4459a668-62eb-45d2-b50e-d4f314d392e9)
