### PR TITLE
Release 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.0
+
+- [feature] Added option `instructions.showWaypointInstructions` to control displaying of waypoint instructions [#313](https://github.com/mapbox/mapbox-gl-directions/pull/313)
+
 ## 4.2.0
 
 - [feature] Display waypoints-related instructions [#310](https://github.com/mapbox/mapbox-gl-directions/pull/310)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-directions",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-directions",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "A mapboxgl plugin for the Mapbox Directions API",
   "main": "./src/index.js",
   "browserify": {


### PR DESCRIPTION
- [feature] Added option `instructions.showWaypointInstructions` to control displaying of waypoint instructions [#313](https://github.com/mapbox/mapbox-gl-directions/pull/313)