### PR TITLE
Use public HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/mapbox/mapbox-gl-directions.git"
+    "url": "git+https://github.com/mapbox/mapbox-gl-directions.git"
   },
   "keywords": [
     "directions",


### PR DESCRIPTION
This updates the package metadata so the public GitHub repository is exposed through an HTTPS Git URL instead of an SSH URL.

Current metadata:

`json
"repository": {
  "type": "git",
  "url": "git+ssh://git@github.com/mapbox/mapbox-gl-directions.git"
}
`

New metadata:

`json
"repository": {
  "type": "git",
  "url": "git+https://github.com/mapbox/mapbox-gl-directions.git"
}
`

This keeps the repository pointing at the same public project while making the npm metadata easier to consume for users and tools that do not have GitHub SSH access configured. No runtime code or dependency changes are included.