### PR TITLE
fix: update repository metadata to https

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/mapbox/mapbox-gl-directions.git"
+    "url": "git+https://github.com/mapbox/mapbox-gl-directions.git"
   },
   "keywords": [
     "directions",


### PR DESCRIPTION
The `repository` field in `package.json` currently uses an SSH URL. This requires package consumers and registry tools to have authenticated SSH GitHub access to resolve the repository metadata.

This PR updates it to an HTTPS URL (`git+https://github.com/...`) which is publicly accessible.
