### PR TITLE
Fix lodash vulnerabilities

### DIFF
--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -1,5 +1,5 @@
 <div class='directions-control directions-control-directions'>
   <div class='mapbox-directions-error'>
-    <%= error %>
+    <%- error %>
   </div>
 </div>

--- a/src/templates/instructions.html
+++ b/src/templates/instructions.html
@@ -37,7 +37,7 @@
             class='mapbox-directions-step'>
             <span class='directions-icon directions-icon-<%= icon %>'></span>
             <div class='mapbox-directions-step-maneuver'>
-              <%= step.maneuver.instruction %>
+              <%- step.maneuver.instruction %>
             </div>
             <% if (distance) { %>
               <div class='mapbox-directions-step-distance'>

--- a/test/test.instructions.js
+++ b/test/test.instructions.js
@@ -2,8 +2,13 @@
 
 const once = require('lodash.once');
 const test = require('tape');
+const template = require('lodash.template');
+const fs = require('fs');
 
 const setup = require('./utils/setup');
+
+const instructionsTemplate = template(fs.readFileSync(__dirname + '/../src/templates/instructions.html', 'utf8'));
+const errorTemplate = template(fs.readFileSync(__dirname + '/../src/templates/error.html', 'utf8'));
 
 test('Directions#instructionControl', tt => {
   tt.test('displayed', t => {
@@ -84,6 +89,38 @@ test('Directions#instructionControl', tt => {
     }));
     directions.setOrigin('Montreal Quebec');
     directions.setDestination('Toledo Spain');
+  });
+
+  tt.test('escapes HTML in step maneuver instructions', t => {
+    const payload = '<img src=x onerror=alert(1)>';
+    const html = instructionsTemplate({
+      routeIndex: 0,
+      routes: 1,
+      steps: [{
+        distance: false,
+        maneuver: {
+          type: 'turn',
+          instruction: payload,
+          location: [0, 0]
+        }
+      }],
+      format: () => '',
+      duration: '1 min',
+      distance: '1 km'
+    });
+
+    t.false(html.includes('<img src=x onerror=alert(1)>'), 'raw payload is not present in rendered HTML');
+    t.ok(html.includes('&lt;img src=x onerror=alert(1)&gt;'), 'payload is HTML-escaped');
+    t.end();
+  });
+
+  tt.test('escapes HTML in error messages', t => {
+    const payload = '<img src=x onerror=alert(1)>';
+    const html = errorTemplate({ error: payload });
+
+    t.false(html.includes('<img src=x onerror=alert(1)>'), 'raw payload is not present in rendered HTML');
+    t.ok(html.includes('&lt;img src=x onerror=alert(1)&gt;'), 'payload is HTML-escaped');
+    t.end();
   });
 
   tt.end();


### PR DESCRIPTION
The lodash templates were using `<%= %>` for rendering route instruction data as raw HTML into the DOM via innerHTML, without any escaping or sanitization. 
This fixes that