### PR TITLE
Fix unsanitized place_name rendering and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.3
+- [bug] Fix unsanitized `place_name` rendering
+
 ## 4.3.2
 - [bug] Fix lodash vulnerabilities
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-directions",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "A mapboxgl plugin for the Mapbox Directions API",
   "main": "./src/index.js",
   "browserify": {

--- a/src/controls/geocoder.js
+++ b/src/controls/geocoder.js
@@ -9,6 +9,16 @@ import utils from '../utils';
 // Once gl-js plugins can be added to custom divs, we should be able to require mapbox-gl-geocoder
 // instead of including it here
 
+function escapeHtml(str) {
+  if (!str) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export default class Geocoder {
   constructor(options) {
     this._ev = new EventEmitter();
@@ -83,6 +93,14 @@ export default class Geocoder {
     if (this.options.container) this.options.position = false;
 
     this._typeahead = new Typeahead(input, [], { filter: false });
+    
+    // Escape place_name before it reaches the library's default render,
+    // since geocoding results are unsanitized and can carry arbitrary HTML.
+    var defaultRender = this._typeahead.render;
+    this._typeahead.render = function(item) {
+      return defaultRender(Object.assign({}, item, { place_name: escapeHtml(item.place_name) }));
+    };
+    
     this._typeahead.getItemValue = function(item) { return item.place_name; };
 
     return el;

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -50,6 +50,7 @@ test('Geocoder#constructor', t =>{
     const geocoder = new Geocoder({});
     geocoder.onAdd();
 
+    geocoder._typeahead.query = 'no-match';
     const malicious = { place_name: '<img src=x onerror=alert(1)>' };
     const rendered = geocoder._typeahead.render(malicious);
 

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -46,5 +46,28 @@ test('Geocoder#constructor', t =>{
     t.end();
   });
 
+  t.test('typeahead render escapes place_name to prevent stored XSS', t => {
+    const geocoder = new Geocoder({});
+    geocoder.onAdd();
+
+    const malicious = { place_name: '<img src=x onerror=alert(1)>' };
+    const rendered = geocoder._typeahead.render(malicious);
+
+    t.equal(rendered, '&lt;img src=x onerror=alert(1)&gt;');
+    t.ok(rendered.indexOf('<img') === -1, 'raw HTML tag is not present in rendered output');
+    t.end();
+  });
+
+  t.test('typeahead render still bolds the matched query substring', t => {
+    const geocoder = new Geocoder({});
+    geocoder.onAdd();
+
+    geocoder._typeahead.query = 'main';
+    const rendered = geocoder._typeahead.render({ place_name: '123 Main St' });
+
+    t.equal(rendered, '123 <strong>Main</strong> St');
+    t.end();
+  });
+
   t.end();
 })


### PR DESCRIPTION
This PR fixes a vulnerability that occurred when the geocoding results included an unsanitized place_name.
Results were being directly rendered without any escaping.

This PR also bumps the version to 4.3.3 so we can do another release.